### PR TITLE
add instance picker

### DIFF
--- a/pkg/ec2instance_connect.go
+++ b/pkg/ec2instance_connect.go
@@ -3,7 +3,6 @@ package pkg
 import (
 	"context"
 	"net"
-
 	"strings"
 
 	"github.com/alexbacchin/ssm-session-client/config"
@@ -33,6 +32,9 @@ func StartEC2InstanceConnect(target string) error {
 		}
 	} else {
 		t = target
+	}
+	if t == "devbox" {
+        t = GetTarget(t)
 	}
 	ssmcfg, err := BuildAWSConfig("ssm")
 	if err != nil {

--- a/pkg/port_forwarder.go
+++ b/pkg/port_forwarder.go
@@ -3,7 +3,6 @@ package pkg
 import (
 	"net"
 	"strings"
-
 	"github.com/alexbacchin/ssm-session-client/config"
 	"github.com/alexbacchin/ssm-session-client/ssmclient"
 	"go.uber.org/zap"
@@ -15,8 +14,11 @@ func StartSSMPortForwarder(target string, sourcePort int) error {
 	if !strings.Contains(target, ":") {
 		target = target + ":22"
 	}
-	t, p, err := net.SplitHostPort(target)
-
+	userHost := strings.Split(target, "@")
+	if len(userHost) != 2 || !strings.Contains(userHost[1], ":") {
+		userHost[1] = userHost[1] + ":22"
+	}
+	t, p, err := net.SplitHostPort(userHost[1])
 	if err == nil {
 		port, err = net.LookupPort("tcp", p)
 		if err != nil {
@@ -24,6 +26,9 @@ func StartSSMPortForwarder(target string, sourcePort int) error {
 		}
 	} else {
 		t = target
+	}
+	if t == "devbox" {
+        t = GetTarget(t)
 	}
 	ssmcfg, err := BuildAWSConfig("ssm")
 	if err != nil {

--- a/pkg/ssm_shell.go
+++ b/pkg/ssm_shell.go
@@ -8,7 +8,9 @@ import (
 
 // StartSSMShell starts a shell session using AWS SSM
 func StartSSMShell(target string) error {
-
+	if target == "devbox" {
+        target = GetTarget(target)
+	}
 	ssmcfg, err := BuildAWSConfig("ssm")
 	if err != nil {
 		zap.S().Fatal(err)

--- a/pkg/ssm_ssh.go
+++ b/pkg/ssm_ssh.go
@@ -30,6 +30,10 @@ func StartSSHSession(target string) error {
 	} else {
 		t = target
 	}
+	if t == "devbox" {
+        t = GetTarget(t)
+	}
+
 	ssmcfg, err := BuildAWSConfig("ssm")
 	if err != nil {
 		zap.S().Fatal(err)


### PR DESCRIPTION
if user uses the hostname "devbox", before trying to run any ec2-instance-connect/ssm commands, it will search for an instance-id named "Developer-<username>", which matches up with their dev box name. 
this will mean if the box is terminated, the user will not need to manually get the new instance id