### PR TITLE
rc2 fixes: Node.js 24, Windows binary improvements, SSH config formatting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,9 @@ on:
     types: [opened, reopened, synchronize]
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,6 +22,9 @@ permissions:
   pages: write
   id-token: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 # Only one concurrent deployment; cancel any in-progress run.
 concurrency:
   group: pages

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -6,6 +6,9 @@ name: binaries
 on:
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   releases-matrix:
     name: Release Go Binary

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -65,7 +65,7 @@ jobs:
       run: |
         go build \
           -ldflags "-X 'github.com/alexbacchin/ssm-session-client/cmd.version=${{ github.ref_name }}'" \
-          -o ssm-session-client-${{ github.ref_name }}-windows-${{ matrix.goarch }}.exe \
+          -o ssm-session-client.exe \
           .
 
     - name: Sign Windows binary
@@ -81,31 +81,35 @@ jobs:
             -n "ssm-session-client" \
             -i "https://github.com/${{ github.repository }}" \
             -t "http://timestamp.digicert.com" \
-            -in ssm-session-client-${{ github.ref_name }}-windows-${{ matrix.goarch }}.exe \
-            -out ssm-session-client-${{ github.ref_name }}-windows-${{ matrix.goarch }}-signed.exe
-          mv ssm-session-client-${{ github.ref_name }}-windows-${{ matrix.goarch }}-signed.exe \
-             ssm-session-client-${{ github.ref_name }}-windows-${{ matrix.goarch }}.exe
+            -in ssm-session-client.exe \
+            -out ssm-session-client-signed.exe
+          mv ssm-session-client-signed.exe ssm-session-client.exe
           rm -f cert.pfx
-          echo "✓ Binary signed successfully"
+          echo "Binary signed successfully"
         else
-          echo "⚠ Skipping signing - WINDOWS_CERT_PFX secret not set"
+          echo "Skipping signing - WINDOWS_CERT_PFX secret not set"
         fi
+
+    - name: Zip Windows binary
+      run: |
+        zip ssm-session-client-${{ github.ref_name }}-windows-${{ matrix.goarch }}.zip \
+          ssm-session-client.exe
 
     - name: Generate checksums
       run: |
-        md5sum ssm-session-client-${{ github.ref_name }}-windows-${{ matrix.goarch }}.exe > \
-          ssm-session-client-${{ github.ref_name }}-windows-${{ matrix.goarch }}.exe.md5
-        sha256sum ssm-session-client-${{ github.ref_name }}-windows-${{ matrix.goarch }}.exe > \
-          ssm-session-client-${{ github.ref_name }}-windows-${{ matrix.goarch }}.exe.sha256
+        md5sum ssm-session-client-${{ github.ref_name }}-windows-${{ matrix.goarch }}.zip > \
+          ssm-session-client-${{ github.ref_name }}-windows-${{ matrix.goarch }}.zip.md5
+        sha256sum ssm-session-client-${{ github.ref_name }}-windows-${{ matrix.goarch }}.zip > \
+          ssm-session-client-${{ github.ref_name }}-windows-${{ matrix.goarch }}.zip.sha256
 
     - name: Upload to release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         gh release upload ${{ github.ref_name }} \
-          ssm-session-client-${{ github.ref_name }}-windows-${{ matrix.goarch }}.exe \
-          ssm-session-client-${{ github.ref_name }}-windows-${{ matrix.goarch }}.exe.md5 \
-          ssm-session-client-${{ github.ref_name }}-windows-${{ matrix.goarch }}.exe.sha256 \
+          ssm-session-client-${{ github.ref_name }}-windows-${{ matrix.goarch }}.zip \
+          ssm-session-client-${{ github.ref_name }}-windows-${{ matrix.goarch }}.zip.md5 \
+          ssm-session-client-${{ github.ref_name }}-windows-${{ matrix.goarch }}.zip.sha256 \
           --clobber
 
   releases-matrix-arm:

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -90,10 +90,15 @@ jobs:
           echo "Skipping signing - WINDOWS_CERT_PFX secret not set"
         fi
 
+    - name: Generate signed executable checksum
+      run: |
+        sha256sum ssm-session-client.exe > ssm-session-client-windows-${{ matrix.goarch }}.exe.sha256
+
     - name: Zip Windows binary
       run: |
         zip ssm-session-client-${{ github.ref_name }}-windows-${{ matrix.goarch }}.zip \
-          ssm-session-client.exe
+          ssm-session-client.exe \
+          ssm-session-client-windows-${{ matrix.goarch }}.exe.sha256
 
     - name: Generate checksums
       run: |
@@ -110,6 +115,7 @@ jobs:
           ssm-session-client-${{ github.ref_name }}-windows-${{ matrix.goarch }}.zip \
           ssm-session-client-${{ github.ref_name }}-windows-${{ matrix.goarch }}.zip.md5 \
           ssm-session-client-${{ github.ref_name }}-windows-${{ matrix.goarch }}.zip.sha256 \
+          ssm-session-client-windows-${{ matrix.goarch }}.exe.sha256 \
           --clobber
 
   releases-matrix-arm:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ env:
   TF_VERSION: "1.9"
   AWS_REGION: us-west-2
   MAKEFILE: test/scripts/Makefile
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   # ---------------------------------------------------------------------------
@@ -45,6 +46,9 @@ jobs:
     name: Acceptance tests
     needs: unit-tests
     runs-on: ubuntu-latest
+    concurrency:
+      group: acceptance-tests-infra
+      cancel-in-progress: false
 
     env:
       # Sanitise the tag for use in resource names (e.g. v1.2.3-rc1 → v1-2-3-rc1).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -240,7 +240,7 @@ jobs:
         run: |
           go build \
             -ldflags "-X 'github.com/alexbacchin/ssm-session-client/cmd.version=${{ github.ref_name }}'" \
-            -o ssm-session-client-${{ github.ref_name }}-windows-${{ matrix.goarch }}.exe \
+            -o ssm-session-client.exe \
             .
 
       - name: Sign Windows binary
@@ -256,29 +256,33 @@ jobs:
               -n "ssm-session-client" \
               -i "https://github.com/${{ github.repository }}" \
               -t "http://timestamp.digicert.com" \
-              -in ssm-session-client-${{ github.ref_name }}-windows-${{ matrix.goarch }}.exe \
-              -out ssm-session-client-${{ github.ref_name }}-windows-${{ matrix.goarch }}-signed.exe
-            mv ssm-session-client-${{ github.ref_name }}-windows-${{ matrix.goarch }}-signed.exe \
-               ssm-session-client-${{ github.ref_name }}-windows-${{ matrix.goarch }}.exe
+              -in ssm-session-client.exe \
+              -out ssm-session-client-signed.exe
+            mv ssm-session-client-signed.exe ssm-session-client.exe
             rm -f cert.pfx
             echo "Binary signed successfully"
           else
             echo "Skipping signing - WINDOWS_CERT_PFX secret not set"
           fi
 
+      - name: Zip Windows binary
+        run: |
+          zip ssm-session-client-${{ github.ref_name }}-windows-${{ matrix.goarch }}.zip \
+            ssm-session-client.exe
+
       - name: Generate checksums
         run: |
-          md5sum ssm-session-client-${{ github.ref_name }}-windows-${{ matrix.goarch }}.exe > \
-            ssm-session-client-${{ github.ref_name }}-windows-${{ matrix.goarch }}.exe.md5
-          sha256sum ssm-session-client-${{ github.ref_name }}-windows-${{ matrix.goarch }}.exe > \
-            ssm-session-client-${{ github.ref_name }}-windows-${{ matrix.goarch }}.exe.sha256
+          md5sum ssm-session-client-${{ github.ref_name }}-windows-${{ matrix.goarch }}.zip > \
+            ssm-session-client-${{ github.ref_name }}-windows-${{ matrix.goarch }}.zip.md5
+          sha256sum ssm-session-client-${{ github.ref_name }}-windows-${{ matrix.goarch }}.zip > \
+            ssm-session-client-${{ github.ref_name }}-windows-${{ matrix.goarch }}.zip.sha256
 
       - name: Upload to release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload ${{ github.ref_name }} \
-            ssm-session-client-${{ github.ref_name }}-windows-${{ matrix.goarch }}.exe \
-            ssm-session-client-${{ github.ref_name }}-windows-${{ matrix.goarch }}.exe.md5 \
-            ssm-session-client-${{ github.ref_name }}-windows-${{ matrix.goarch }}.exe.sha256 \
+            ssm-session-client-${{ github.ref_name }}-windows-${{ matrix.goarch }}.zip \
+            ssm-session-client-${{ github.ref_name }}-windows-${{ matrix.goarch }}.zip.md5 \
+            ssm-session-client-${{ github.ref_name }}-windows-${{ matrix.goarch }}.zip.sha256 \
             --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -265,10 +265,15 @@ jobs:
             echo "Skipping signing - WINDOWS_CERT_PFX secret not set"
           fi
 
+      - name: Generate signed executable checksum
+        run: |
+          sha256sum ssm-session-client.exe > ssm-session-client-windows-${{ matrix.goarch }}.exe.sha256
+
       - name: Zip Windows binary
         run: |
           zip ssm-session-client-${{ github.ref_name }}-windows-${{ matrix.goarch }}.zip \
-            ssm-session-client.exe
+            ssm-session-client.exe \
+            ssm-session-client-windows-${{ matrix.goarch }}.exe.sha256
 
       - name: Generate checksums
         run: |
@@ -285,4 +290,5 @@ jobs:
             ssm-session-client-${{ github.ref_name }}-windows-${{ matrix.goarch }}.zip \
             ssm-session-client-${{ github.ref_name }}-windows-${{ matrix.goarch }}.zip.md5 \
             ssm-session-client-${{ github.ref_name }}-windows-${{ matrix.goarch }}.zip.sha256 \
+            ssm-session-client-windows-${{ matrix.goarch }}.exe.sha256 \
             --clobber

--- a/session/ssh_config.go
+++ b/session/ssh_config.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"bufio"
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
@@ -85,16 +86,15 @@ func resolveConfigFiles(configFile string) []string {
 
 // parseSSHConfigFile parses an SSH config file into a list of Host blocks.
 func parseSSHConfigFile(path string) ([]sshConfigBlock, error) {
-	f, err := os.Open(path)
+	raw, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
 
 	var blocks []sshConfigBlock
 	var current *sshConfigBlock
 
-	scanner := bufio.NewScanner(f)
+	scanner := bufio.NewScanner(bytes.NewReader(normalizeFileEncoding(raw)))
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 
@@ -263,6 +263,43 @@ func matchGlob(s, pattern string) bool {
 		}
 	}
 	return len(s) == 0
+}
+
+// normalizeFileEncoding detects and converts common Windows file encodings to UTF-8.
+// It handles:
+//   - UTF-16 LE (BOM 0xFF 0xFE): PowerShell Out-File / ">" redirect default on Windows 5.x
+//   - UTF-16 BE (BOM 0xFE 0xFF): uncommon but valid
+//   - UTF-8 BOM (0xEF 0xBB 0xBF): PowerShell Set-Content -Encoding UTF8 on Windows 5.x,
+//     and Windows editors such as Notepad
+//
+// SSH config files contain only ASCII characters, so UTF-16 decoding simply
+// extracts the non-null bytes from each two-byte code unit.
+func normalizeFileEncoding(data []byte) []byte {
+	// UTF-16 LE BOM: FF FE
+	if len(data) >= 2 && data[0] == 0xFF && data[1] == 0xFE {
+		out := make([]byte, 0, len(data)/2)
+		for i := 2; i+1 < len(data); i += 2 {
+			if data[i+1] == 0x00 {
+				out = append(out, data[i])
+			}
+		}
+		return out
+	}
+	// UTF-16 BE BOM: FE FF
+	if len(data) >= 2 && data[0] == 0xFE && data[1] == 0xFF {
+		out := make([]byte, 0, len(data)/2)
+		for i := 2; i+1 < len(data); i += 2 {
+			if data[i] == 0x00 {
+				out = append(out, data[i+1])
+			}
+		}
+		return out
+	}
+	// UTF-8 BOM: EF BB BF
+	if len(data) >= 3 && data[0] == 0xEF && data[1] == 0xBB && data[2] == 0xBF {
+		return data[3:]
+	}
+	return data
 }
 
 // expandTilde expands a leading ~ to the user's home directory.

--- a/session/ssh_config_test.go
+++ b/session/ssh_config_test.go
@@ -150,6 +150,94 @@ func TestParseSSHConfig_EqualsFormat(t *testing.T) {
 	}
 }
 
+func TestParseSSHConfig_WindowsCRLF(t *testing.T) {
+	dir := t.TempDir()
+	configFile := filepath.Join(dir, "config")
+	// Simulate a file saved on Windows with CRLF line endings.
+	content := "Host my-ec2\r\n  HostName i-0123456789abcdef0\r\n  User ec2-user\r\n"
+	if err := os.WriteFile(configFile, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := ParseSSHConfig(configFile, "my-ec2")
+
+	if cfg.HostName != "i-0123456789abcdef0" {
+		t.Errorf("expected HostName=i-0123456789abcdef0, got %q", cfg.HostName)
+	}
+	if cfg.User != "ec2-user" {
+		t.Errorf("expected User=ec2-user, got %q", cfg.User)
+	}
+}
+
+func TestParseSSHConfig_WindowsBOM(t *testing.T) {
+	dir := t.TempDir()
+	configFile := filepath.Join(dir, "config")
+	// Simulate a file with a UTF-8 BOM — added by Notepad and some Windows editors.
+	const bom = "\xef\xbb\xbf"
+	content := bom + "Host my-ec2\n  HostName i-0123456789abcdef0\n  User ec2-user\n"
+	if err := os.WriteFile(configFile, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := ParseSSHConfig(configFile, "my-ec2")
+
+	if cfg.HostName != "i-0123456789abcdef0" {
+		t.Errorf("expected HostName=i-0123456789abcdef0, got %q (BOM not stripped?)", cfg.HostName)
+	}
+	if cfg.User != "ec2-user" {
+		t.Errorf("expected User=ec2-user, got %q", cfg.User)
+	}
+}
+
+func TestParseSSHConfig_WindowsBOMAndCRLF(t *testing.T) {
+	dir := t.TempDir()
+	configFile := filepath.Join(dir, "config")
+	// Simulate a file with both UTF-8 BOM and CRLF line endings.
+	const bom = "\xef\xbb\xbf"
+	content := bom + "Host my-ec2\r\n  HostName i-0123456789abcdef0\r\n  User ec2-user\r\n"
+	if err := os.WriteFile(configFile, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := ParseSSHConfig(configFile, "my-ec2")
+
+	if cfg.HostName != "i-0123456789abcdef0" {
+		t.Errorf("expected HostName=i-0123456789abcdef0, got %q (BOM+CRLF not handled?)", cfg.HostName)
+	}
+	if cfg.User != "ec2-user" {
+		t.Errorf("expected User=ec2-user, got %q", cfg.User)
+	}
+}
+
+// utf16LE encodes an ASCII string as UTF-16 LE bytes with BOM, mimicking
+// PowerShell 5.x Out-File / ">" redirect default output.
+func utf16LE(s string) []byte {
+	out := []byte{0xFF, 0xFE} // BOM
+	for i := 0; i < len(s); i++ {
+		out = append(out, s[i], 0x00)
+	}
+	return out
+}
+
+func TestParseSSHConfig_PowerShellUTF16LE(t *testing.T) {
+	dir := t.TempDir()
+	configFile := filepath.Join(dir, "config")
+	// PowerShell 5.x Out-File and ">" write UTF-16 LE with BOM by default.
+	content := "Host my-ec2\r\n  HostName i-0123456789abcdef0\r\n  User ec2-user\r\n"
+	if err := os.WriteFile(configFile, utf16LE(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := ParseSSHConfig(configFile, "my-ec2")
+
+	if cfg.HostName != "i-0123456789abcdef0" {
+		t.Errorf("expected HostName=i-0123456789abcdef0, got %q (UTF-16 LE not handled?)", cfg.HostName)
+	}
+	if cfg.User != "ec2-user" {
+		t.Errorf("expected User=ec2-user, got %q", cfg.User)
+	}
+}
+
 func TestMatchGlob(t *testing.T) {
 	tests := []struct {
 		s, pattern string


### PR DESCRIPTION
## Summary

- **Node.js 24 for action runners**: All four workflow files opt into Node.js 24 via `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` to avoid deprecation warnings from actions still using Node.js 20.
- **Windows binaries released as ZIP files**: Windows executables are now packaged as ZIP files for download.
- **Fixed Windows SSH config file formatting**: Corrected formatting issue in SSH config files generated on Windows.
- **Windows SHA256 checksum in ZIP and as release artifact**: After signing, a per-arch SHA256 of the `.exe` (`ssm-session-client-windows-<arch>.exe.sha256`) is generated, included inside the ZIP, and also uploaded as a standalone release artifact.

## Test plan

- [ ] Trigger a release and verify Windows ZIPs contain both `ssm-session-client.exe` and `ssm-session-client-windows-<arch>.exe.sha256`
- [ ] Verify `ssm-session-client-windows-amd64.exe.sha256` and `ssm-session-client-windows-arm64.exe.sha256` appear as separate release assets
- [ ] Verify SSH config files are correctly formatted on Windows
- [ ] Confirm no Node.js 20 deprecation warnings in workflow runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)