### PR TITLE
Fix mux port-forwarding session dying on WebSocket close

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -737,13 +737,20 @@ ssm-session-client port-forwarding  devbox:443 8443</code></pre>
       <!-- Reconnection -->
       <h2 id="config-reconnect">Automatic Reconnection</h2>
       <p>
-        <code>ssm-session-client</code> automatically reconnects when a WebSocket connection
-        drops. Configure it with:
+        For <strong>multiplexed port forwarding</strong> (SSM agent ≥ 3.0.196.0),
+        <code>ssm-session-client</code> automatically reopens the SSM session when the
+        underlying WebSocket drops — for example, due to a proxy idle-timeout or a
+        transient network interruption. The local TCP listener stays open throughout, so
+        connected clients can reconnect without restarting the tool.
       </p>
       <ul>
         <li><code>--enable-reconnect</code> — enable/disable (default: <code>true</code>)</li>
         <li><code>--max-reconnects</code> — maximum attempts before giving up (default: <code>5</code>, set <code>0</code> for unlimited)</li>
       </ul>
+      <div class="callout callout-info">
+        Automatic reconnection applies to multiplexed port forwarding only. Shell and SSH
+        sessions are not reconnected automatically.
+      </div>
 
       <!-- Data Channel Encryption -->
       <h2 id="config-encryption">Data Channel Encryption</h2>
@@ -1011,31 +1018,27 @@ ssh ec2-user@i-0bdb4f892de4bb54c</code></pre>
         Securely tunnel TCP traffic to a port on a private instance without SSH,
         open firewall rules, or a bastion host.
       </p>
-<pre><code class="language-bash"># Forward local port 8888 → instance port 443
-ssm-session-client port-forwarding i-0bdb4f892de4bb54c:443 8888
+<pre><code class="language-bash"># Forward local port 2222 → instance port 22
+ssm-session-client port-forwarding i-0bdb4f892de4bb54c --remote-port 22 --local-port 2222
 
 # Auto-assign local port (prints the assigned port)
-ssm-session-client port-forwarding i-0bdb4f892de4bb54c:443
+ssm-session-client port-forwarding i-0bdb4f892de4bb54c --remote-port 443
 
-# Forward to a different host (via the instance as gateway)
-ssm-session-client port-forwarding i-0bdb4f892de4bb54c:internal-db.local:5432 5432
+# Forward to a different host reachable from the instance (e.g. a private RDS endpoint)
+ssm-session-client port-forwarding i-0bdb4f892de4bb54c --remote-port 5432 --host db.internal --local-port 5432
 
 # Using an alias
-ssm-session-client port-forwarding devbox:443 8443</code></pre>
+ssm-session-client port-forwarding devbox --remote-port 443 --local-port 8443</code></pre>
 
-      <h3>Target Syntax</h3>
-      <p>
-        The first argument specifies the target and remote port in the format:
-        <code><strong>target</strong>[:<strong>remoteHost</strong>]:<strong>remotePort</strong></code>
-      </p>
+      <h3>Flags</h3>
       <div class="table-wrap">
         <table>
-          <thead><tr><th>Component</th><th>Description</th><th>Example</th></tr></thead>
+          <thead><tr><th>Flag</th><th>Description</th><th>Example</th></tr></thead>
           <tbody>
-            <tr><td><code>target</code></td><td>Instance ID, alias, tag, IP, or DNS name (resolved like other commands)</td><td><code>i-0123456789abcdef0</code>, <code>devbox</code>, <code>10.0.1.5</code></td></tr>
-            <tr><td><code>remoteHost</code> (optional)</td><td>Hostname or IP on the instance to forward to (if omitted, defaults to the instance itself)</td><td><code>internal-db.local</code>, <code>127.0.0.1</code></td></tr>
-            <tr><td><code>remotePort</code></td><td>Port on the instance (or remoteHost) to forward to</td><td><code>443</code>, <code>5432</code></td></tr>
-            <tr><td><code>localPort</code> (second arg)</td><td>Local listening port (omit or set to 0 for auto-assign)</td><td><code>8888</code></td></tr>
+            <tr><td><code>&lt;target&gt;</code></td><td>Instance ID, alias, tag, IP, or DNS name (resolved like other commands)</td><td><code>i-0123456789abcdef0</code>, <code>devbox</code>, <code>10.0.1.5</code></td></tr>
+            <tr><td><code>--remote-port</code></td><td>Port on the instance (or <code>--host</code>) to forward to (required)</td><td><code>--remote-port 5432</code></td></tr>
+            <tr><td><code>--host</code></td><td>Optional hostname or IP reachable from the instance to forward to instead of the instance itself</td><td><code>--host db.internal</code></td></tr>
+            <tr><td><code>--local-port</code></td><td>Local listening port (omit for auto-assign)</td><td><code>--local-port 8888</code></td></tr>
           </tbody>
         </table>
       </div>
@@ -1046,11 +1049,18 @@ ssm-session-client port-forwarding devbox:443 8443</code></pre>
         allowing multiple concurrent TCP connections over a single SSM session. Older
         agents fall back to single-connection mode automatically.
       </div>
+      <div class="callout callout-tip">
+        <strong>Automatic reconnection:</strong> If the WebSocket drops (e.g. proxy
+        idle-timeout), the session is re-established automatically and the local port
+        keeps listening. Use <code>--enable-reconnect=false</code> to disable, or
+        <code>--max-reconnects N</code> to limit attempts. See
+        <a href="#config-reconnect">Automatic Reconnection</a> for details.
+      </div>
 
       <h3>Common use cases</h3>
       <ul>
-        <li><strong>Tunnel to a database on the instance:</strong> <code>ssm-session-client port-forwarding i-abc123:5432 5432</code> → connect to <code>localhost:5432</code></li>
-        <li><strong>Tunnel through an instance to another service:</strong> <code>ssm-session-client port-forwarding bastion:internal-api.local:8080 8080</code> → forwards to <code>internal-api.local:8080</code> as seen from the bastion instance</li>
+        <li><strong>Tunnel to a database on the instance:</strong> <code>ssm-session-client port-forwarding i-abc123 --remote-port 5432 --local-port 5432</code> → connect to <code>localhost:5432</code></li>
+        <li><strong>Tunnel through an instance to another service:</strong> <code>ssm-session-client port-forwarding bastion --remote-port 8080 --host internal-api.local --local-port 8080</code> → forwards to <code>internal-api.local:8080</code> as seen from the bastion instance</li>
         <li><strong>Multiple tunnels in parallel:</strong> Open multiple port-forwarding sessions in separate terminals</li>
       </ul>
 

--- a/session/port_forwarder.go
+++ b/session/port_forwarder.go
@@ -24,10 +24,12 @@ func StartSSMPortForwarder(target string, localPort int, remotePort int, remoteH
 	}
 
 	in := ssmclient.PortForwardingInput{
-		Target:     tgt,
-		RemotePort: remotePort,
-		LocalPort:  localPort,
-		Host:       remoteHost,
+		Target:          tgt,
+		RemotePort:      remotePort,
+		LocalPort:       localPort,
+		Host:            remoteHost,
+		EnableReconnect: config.Flags().EnableReconnect,
+		MaxReconnects:   config.Flags().MaxReconnects,
 	}
 	ssmMessagesCfg, err := BuildAWSConfig(context.Background(), "ssmmessages")
 	if err != nil {

--- a/ssmclient/port_forwarding.go
+++ b/ssmclient/port_forwarding.go
@@ -24,11 +24,13 @@ import (
 // RemotePort is the port on the EC2 instance to connect to.
 // LocalPort is the port on the local host to listen to.  If not provided, a random port will be used.
 type PortForwardingInput struct {
-	Target     string
-	RemotePort int
-	LocalPort  int
-	Host       string        // optional
-	ReadyCh    chan struct{} // optional; closed when the TCP listener is ready
+	Target          string
+	RemotePort      int
+	LocalPort       int
+	Host            string        // optional
+	ReadyCh         chan struct{}  // optional; closed when the TCP listener is ready
+	EnableReconnect bool          // reconnect on WebSocket close (mux mode only)
+	MaxReconnects   int           // 0 = unlimited; ignored when EnableReconnect is false
 }
 
 // PortForwardingSession starts a port forwarding session using the PortForwardingInput parameters to
@@ -113,6 +115,7 @@ func startMuxPortForwardingSession(ctx context.Context, c *datachannel.SsmDataCh
 	zap.S().Infof("listening on %s", lsnr.Addr())
 
 	current := c
+	reconnectCount := 0
 	for {
 		bridgeErr := startMuxPortForwarding(ctx, current, lsnr, current.AgentVersion())
 
@@ -124,14 +127,22 @@ func startMuxPortForwardingSession(ctx context.Context, c *datachannel.SsmDataCh
 		default:
 		}
 
-		// Bridge died but context is still live — attempt reconnect.
 		_ = current.TerminateSession()
 		_ = current.Close()
 
+		if !opts.EnableReconnect {
+			return bridgeErr
+		}
+
+		if opts.MaxReconnects > 0 && reconnectCount >= opts.MaxReconnects {
+			return fmt.Errorf("max reconnects (%d) reached: %w", opts.MaxReconnects, bridgeErr)
+		}
+		reconnectCount++
+
 		if bridgeErr != nil {
-			zap.S().Warnf("mux bridge ended (%v), reconnecting…", bridgeErr)
+			zap.S().Warnf("mux bridge ended (%v), reconnecting (attempt %d)…", bridgeErr, reconnectCount)
 		} else {
-			zap.S().Info("mux bridge ended, reconnecting…")
+			zap.S().Infof("mux bridge ended, reconnecting (attempt %d)…", reconnectCount)
 		}
 
 		next, rerr := openDataChannel(cfg, opts)
@@ -144,7 +155,7 @@ func startMuxPortForwardingSession(ctx context.Context, c *datachannel.SsmDataCh
 			return fmt.Errorf("reconnect handshake failed: %w", herr)
 		}
 
-		zap.S().Infof("reconnected (agent version: %s)", next.AgentVersion())
+		zap.S().Infof("reconnected (attempt %d, agent version: %s)", reconnectCount, next.AgentVersion())
 		current = next
 	}
 }

--- a/ssmclient/port_forwarding.go
+++ b/ssmclient/port_forwarding.go
@@ -2,6 +2,7 @@ package ssmclient
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net"
 	"os"
@@ -40,13 +41,8 @@ func PortForwardingSessionWithContext(ctx context.Context, cfg aws.Config, opts 
 	if err != nil {
 		return err
 	}
-	defer func() {
-		// Both the basic and muxing plugins support TerminateSession on the agent side.
-		_ = c.TerminateSession()
-		_ = c.Close()
-	}()
 
-	return startPortForwardingSession(ctx, c, opts)
+	return startPortForwardingSession(ctx, cfg, c, opts)
 }
 
 // PortForwardingSession starts a port forwarding session using the PortForwardingInput parameters to
@@ -57,11 +53,6 @@ func PortForwardingSession(cfg aws.Config, opts *PortForwardingInput) error {
 	if err != nil {
 		return err
 	}
-	defer func() {
-		// Both the basic and muxing plugins support TerminateSession on the agent side.
-		_ = c.TerminateSession()
-		_ = c.Close()
-	}()
 
 	// use a signal handler vs. defer since defer operates after an escape from the outer loop
 	// and we can't trust the data channel connection state at that point.  Intercepting signals
@@ -69,13 +60,17 @@ func PortForwardingSession(cfg aws.Config, opts *PortForwardingInput) error {
 	// possibility that the data channel is still valid
 	installSignalHandler(c)
 
-	return startPortForwardingSession(context.Background(), c, opts)
+	return startPortForwardingSession(context.Background(), cfg, c, opts)
 }
 
 // startPortForwardingSession is shared by PortForwardingSession and PortForwardingSessionWithContext
 // and routes to either multiplexed or basic port forwarding based on agent version.
-func startPortForwardingSession(ctx context.Context, c *datachannel.SsmDataChannel, opts *PortForwardingInput) error {
+// For mux mode, ownership of c transfers to startMuxPortForwardingSession (which closes it).
+// For basic mode, the caller retains no deferred close, so we close c here on exit.
+func startPortForwardingSession(ctx context.Context, cfg aws.Config, c *datachannel.SsmDataChannel, opts *PortForwardingInput) error {
 	if err := c.WaitForHandshakeComplete(ctx); err != nil {
+		_ = c.TerminateSession()
+		_ = c.Close()
 		return err
 	}
 
@@ -84,16 +79,22 @@ func startPortForwardingSession(ctx context.Context, c *datachannel.SsmDataChann
 	// Agent version 3.0.196.0+ supports multiplexed port forwarding
 	if agentVersionGte(agentVersion, "3.0.196.0") {
 		zap.S().Infof("using multiplexed port forwarding (agent version: %s)", agentVersion)
-		return startMuxPortForwardingSession(ctx, c, opts)
+		// Ownership of c passes to startMuxPortForwardingSession; it closes c on every iteration.
+		return startMuxPortForwardingSession(ctx, c, opts, cfg)
 	}
 
 	zap.S().Infof("using basic port forwarding (agent version: %s)", agentVersion)
+	defer func() {
+		_ = c.TerminateSession()
+		_ = c.Close()
+	}()
 	return startBasicPortForwardingSession(ctx, c, opts)
 }
 
 // startMuxPortForwardingSession handles multiplexed port forwarding for modern SSM agents.
-func startMuxPortForwardingSession(ctx context.Context, c *datachannel.SsmDataChannel, opts *PortForwardingInput) error {
-	// Create listener without connection limit for multiplexed mode
+// It keeps the TCP listener open across WebSocket reconnects so clients can transparently
+// reconnect after a proxy idle-timeout or transient network interruption.
+func startMuxPortForwardingSession(ctx context.Context, c *datachannel.SsmDataChannel, opts *PortForwardingInput, cfg aws.Config) error {
 	lsnr, err := createListenerUnlimited(opts.LocalPort)
 	if err != nil {
 		return err
@@ -111,7 +112,41 @@ func startMuxPortForwardingSession(ctx context.Context, c *datachannel.SsmDataCh
 
 	zap.S().Infof("listening on %s", lsnr.Addr())
 
-	return startMuxPortForwarding(ctx, c, lsnr, c.AgentVersion())
+	current := c
+	for {
+		bridgeErr := startMuxPortForwarding(ctx, current, lsnr, current.AgentVersion())
+
+		select {
+		case <-ctx.Done():
+			_ = current.TerminateSession()
+			_ = current.Close()
+			return nil
+		default:
+		}
+
+		// Bridge died but context is still live — attempt reconnect.
+		_ = current.TerminateSession()
+		_ = current.Close()
+
+		if bridgeErr != nil {
+			zap.S().Warnf("mux bridge ended (%v), reconnecting…", bridgeErr)
+		} else {
+			zap.S().Info("mux bridge ended, reconnecting…")
+		}
+
+		next, rerr := openDataChannel(cfg, opts)
+		if rerr != nil {
+			return fmt.Errorf("reconnect failed: %w", rerr)
+		}
+
+		if herr := next.WaitForHandshakeComplete(ctx); herr != nil {
+			_ = next.Close()
+			return fmt.Errorf("reconnect handshake failed: %w", herr)
+		}
+
+		zap.S().Infof("reconnected (agent version: %s)", next.AgentVersion())
+		current = next
+	}
 }
 
 // startBasicPortForwardingSession handles legacy single-connection port forwarding.

--- a/ssmclient/port_mux.go
+++ b/ssmclient/port_mux.go
@@ -37,6 +37,12 @@ func startMuxPortForwarding(ctx context.Context, c *datachannel.SsmDataChannel, 
 		return fmt.Errorf("create smux session: %w", err)
 	}
 
+	// acceptCtx is cancelled when the bridge dies so the accept goroutine stops
+	// dispatching new connections to this (now-dead) muxSession before the caller
+	// starts the next reconnect iteration with a fresh session.
+	acceptCtx, cancelAccept := context.WithCancel(ctx)
+	defer cancelAccept()
+
 	// Start bridge goroutines between data channel and smux pipe
 	errCh := make(chan error, 2)
 
@@ -61,10 +67,12 @@ func startMuxPortForwarding(ctx context.Context, c *datachannel.SsmDataChannel, 
 	}()
 
 	// Accept loop: handle incoming TCP connections
+	acceptDone := make(chan struct{})
 	go func() {
+		defer close(acceptDone)
 		for {
 			select {
-			case <-ctx.Done():
+			case <-acceptCtx.Done():
 				return
 			default:
 			}
@@ -72,7 +80,7 @@ func startMuxPortForwarding(ctx context.Context, c *datachannel.SsmDataChannel, 
 			conn, err := listener.Accept()
 			if err != nil {
 				select {
-				case <-ctx.Done():
+				case <-acceptCtx.Done():
 					return
 				default:
 					if errors.Is(err, net.ErrClosed) {
@@ -84,7 +92,7 @@ func startMuxPortForwarding(ctx context.Context, c *datachannel.SsmDataChannel, 
 			}
 
 			// Handle each connection in a separate goroutine
-			go handleMuxConnection(ctx, muxSession, conn)
+			go handleMuxConnection(acceptCtx, muxSession, conn)
 		}
 	}()
 
@@ -97,6 +105,15 @@ func startMuxPortForwarding(ctx context.Context, c *datachannel.SsmDataChannel, 
 			zap.S().Warnf("bridge error: %v", err)
 		}
 		err = nil
+	}
+
+	// Stop the accept goroutine before tearing down the session so it cannot
+	// dispatch new connections to the dead muxSession during reconnect.
+	cancelAccept()
+	select {
+	case <-acceptDone:
+	case <-time.After(2 * time.Second):
+		zap.S().Debug("timed out waiting for accept goroutine to exit")
 	}
 
 	// Close the pipe to unblock bridge goroutines. The WriteTo goroutine

--- a/ssmclient/port_mux.go
+++ b/ssmclient/port_mux.go
@@ -2,6 +2,7 @@ package ssmclient
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -72,9 +73,11 @@ func startMuxPortForwarding(ctx context.Context, c *datachannel.SsmDataChannel, 
 			if err != nil {
 				select {
 				case <-ctx.Done():
-					// Expected error during shutdown
 					return
 				default:
+					if errors.Is(err, net.ErrClosed) {
+						return
+					}
 					zap.S().Warnf("accept error: %v", err)
 					continue
 				}

--- a/test/acceptance/port_forwarding_acceptance_test.go
+++ b/test/acceptance/port_forwarding_acceptance_test.go
@@ -12,6 +12,11 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
+	"github.com/aws/aws-sdk-go-v2/aws"
 )
 
 // TestPortForwardingToSSHPort forwards a local port to port 22 on the test instance and verifies
@@ -85,6 +90,154 @@ func TestPortForwardingMultipleConnections(t *testing.T) {
 	// Give the port-forwarder process time to process the smux stream closures
 	// and begin session termination before the leak check runs.
 	time.Sleep(2 * time.Second)
+}
+
+// TestPortForwardingReconnect verifies that a mux port-forwarding session recovers after the
+// underlying SSM session is terminated externally (simulating a proxy idle-timeout or network drop).
+// The test:
+//  1. Starts a port-forwarder with --enable-reconnect=true
+//  2. Confirms the first TCP connection succeeds (SSH banner received)
+//  3. Terminates the active SSM session via the API (simulates WebSocket close)
+//  4. Waits for the port-forwarder to re-open the port (reconnect + new handshake)
+//  5. Confirms a second TCP connection succeeds
+func TestPortForwardingReconnect(t *testing.T) {
+	i := infra(t)
+	waitForSSMReady(t, i.InstanceID)
+	terminateAllSessions(t, i.InstanceID)
+
+	localPort := freePort(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	stderrBuf := &strings.Builder{}
+	args := []string{
+		"--config", "/dev/null",
+		"--log-level", "debug",
+		"--aws-region", i.AWSRegion,
+		"--enable-reconnect=true",
+		"--max-reconnects", "3",
+		"port-forwarding", i.InstanceID,
+		"--remote-port", "22",
+		"--local-port", strconv.Itoa(localPort),
+	}
+	cmd := exec.CommandContext(ctx, binaryPath, args...) //nolint:gosec
+	cmd.Stderr = stderrBuf
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start port-forwarding: %v", err)
+	}
+
+	exited := make(chan struct{})
+	go func() {
+		cmd.Wait() //nolint:errcheck
+		close(exited)
+	}()
+
+	t.Cleanup(func() {
+		if cmd.Process != nil {
+			cmd.Process.Signal(os.Interrupt) //nolint:errcheck
+		}
+		select {
+		case <-exited:
+		case <-time.After(5 * time.Second):
+			cancel()
+			<-exited
+		}
+		t.Logf("port-forwarding stderr:\n%s", stderrBuf.String())
+	})
+
+	// Wait for the port to open (initial connection).
+	if !portReady(localPort, 40*time.Second, exited) {
+		t.Fatalf("port %d not ready after initial connect (stderr: %s)", localPort, stderrBuf.String())
+	}
+
+	// Verify first connection works.
+	if err := sshBannerCheck(t, localPort); err != nil {
+		t.Fatalf("first connection: %v", err)
+	}
+	t.Log("first connection succeeded")
+
+	// Find the active SSM session and terminate it externally.
+	sessionID := findActiveSession(t, i.InstanceID)
+	if sessionID == "" {
+		t.Fatal("no active SSM session found to terminate")
+	}
+	t.Logf("terminating SSM session %s to trigger reconnect", sessionID)
+	terminateSessionByID(t, sessionID)
+
+	// Port-forwarder should detect the WebSocket close and reconnect.
+	// Wait up to 60s for the port to become available again.
+	if !portReady(localPort, 60*time.Second, exited) {
+		t.Fatalf("port %d not ready after reconnect (stderr: %s)", localPort, stderrBuf.String())
+	}
+
+	// Verify second connection works after reconnect.
+	if err := sshBannerCheck(t, localPort); err != nil {
+		t.Fatalf("second connection after reconnect: %v", err)
+	}
+	t.Log("reconnect verified: second connection succeeded")
+}
+
+// sshBannerCheck dials localhost:port and reads the SSH banner.
+func sshBannerCheck(t *testing.T, port int) error {
+	t.Helper()
+	conn, err := net.DialTimeout("tcp", fmt.Sprintf("localhost:%d", port), 5*time.Second)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	buf := make([]byte, 256)
+	_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	n, _ := conn.Read(buf)
+	if n == 0 {
+		return fmt.Errorf("no data received (SSH banner missing)")
+	}
+	t.Logf("SSH banner: %s", strings.TrimSpace(string(buf[:n])))
+	return nil
+}
+
+// findActiveSession returns the first active SSM session ID for the given instance, or "".
+func findActiveSession(t *testing.T, instanceID string) string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	cfg, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(globalInfraOutputs.AWSRegion))
+	if err != nil {
+		t.Logf("findActiveSession: load config: %v", err)
+		return ""
+	}
+	client := ssm.NewFromConfig(cfg)
+	out, err := client.DescribeSessions(ctx, &ssm.DescribeSessionsInput{
+		State: ssmtypes.SessionStateActive,
+		Filters: []ssmtypes.SessionFilter{
+			{Key: ssmtypes.SessionFilterKeyTargetId, Value: aws.String(instanceID)},
+		},
+	})
+	if err != nil || len(out.Sessions) == 0 {
+		return ""
+	}
+	if out.Sessions[0].SessionId == nil {
+		return ""
+	}
+	return *out.Sessions[0].SessionId
+}
+
+// terminateSessionByID calls ssm:TerminateSession for the given session ID.
+func terminateSessionByID(t *testing.T, sessionID string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	cfg, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(globalInfraOutputs.AWSRegion))
+	if err != nil {
+		t.Fatalf("terminateSessionByID: load config: %v", err)
+	}
+	client := ssm.NewFromConfig(cfg)
+	if _, err := client.TerminateSession(ctx, &ssm.TerminateSessionInput{SessionId: aws.String(sessionID)}); err != nil {
+		t.Fatalf("terminateSessionByID %s: %v", sessionID, err)
+	}
 }
 
 // TestPortForwardingToRDPPort forwards a local port to port 3389 on the Windows test instance

--- a/test/acceptance/sso_acceptance_test.go
+++ b/test/acceptance/sso_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build acceptance
+//go:build acceptance && sso
 
 package acceptance
 

--- a/test/scripts/Makefile
+++ b/test/scripts/Makefile
@@ -82,6 +82,22 @@ acceptance-run-local: ## Run acceptance tests locally (requires infra to be prov
 acceptance-run-ci: ## Run acceptance tests in CI (identical to local; relies on OIDC credentials).
 	$(MAKE) acceptance-run-local
 
+acceptance-run-sso: ## Run SSO acceptance tests (requires SSC_SSO_TEST_PROFILE env var and cached SSO token).
+	@if [ -z "$(SSO_PROFILE)" ]; then \
+		echo "ERROR: SSO_PROFILE is required.  Usage: make acceptance-run-sso SSO_PROFILE=my-sso-profile" >&2; \
+		exit 1; \
+	fi
+	cd $(TEST_DIR)/.. && \
+		SSC_SSO_TEST_PROFILE=$(SSO_PROFILE) \
+		go test ./test/acceptance/... \
+			-tags "acceptance sso" \
+			-v \
+			-timeout 20m \
+			-count=1 \
+			-race \
+			-run TestSSOLogin \
+			$(ACCEPTANCE_ARGS)
+
 acceptance-sso-interactive: ## Run interactive SSO login test (requires a human to approve in a browser).
 	@if [ -z "$(SSO_PROFILE)" ]; then \
 		echo "ERROR: SSO_PROFILE is required.  Usage: make acceptance-sso-interactive SSO_PROFILE=my-sso-profile" >&2; \
@@ -92,7 +108,7 @@ acceptance-sso-interactive: ## Run interactive SSO login test (requires a human 
 		SSC_SSO_TEST_INTERACTIVE=1 \
 		SSC_SSO_TEST_TIMEOUT=$(SSO_TEST_TIMEOUT) \
 		go test ./test/acceptance/... \
-			-tags acceptance \
+			-tags "acceptance sso" \
 			-v \
 			-timeout $$(( $(SSO_TEST_TIMEOUT) + 5 ))m \
 			-count=1 \


### PR DESCRIPTION
## Summary

- **Reconnection loop**: When the smux bridge dies but the context is still live (proxy idle-timeout, transient network blip), `startMuxPortForwardingSession` now terminates the dead channel, opens a fresh SSM session, waits for handshake, and resumes — keeping the TCP listener open throughout so clients can reconnect transparently without restarting the tool.
- **Spurious warning suppressed**: The accept goroutine in `startMuxPortForwarding` now returns silently on `net.ErrClosed` instead of logging a warning and spinning when the listener is closed internally.
- **Stale goroutine race fixed**: The accept goroutine is now scoped to `acceptCtx` and fully drained before `startMuxPortForwarding` returns, preventing it from dispatching new TCP connections to the dead muxSession during a reconnect iteration.
- **Channel ownership clarified**: Removed the `defer TerminateSession/Close` from the two public entry points (`PortForwardingSession`, `PortForwardingSessionWithContext`); ownership now flows into `startMuxPortForwardingSession` for the mux path and into `startBasicPortForwardingSession` via a local defer for the basic path.
- **Documentation corrected**: Port-forwarding command examples in `docs/index.html` were using a non-existent positional `target:port` syntax; updated to use the actual `--remote-port`, `--host`, and `--local-port` flags. Added reconnection documentation and an info callout.
- **SSO tests isolated**: SSO acceptance tests moved to a separate `acceptance && sso` build tag, excluded from `make acceptance-run-local` and all CI runs. New `make acceptance-run-sso` target for explicit opt-in execution.

## Root causes addressed

1. No reconnection logic existed for the mux path — a single WebSocket close (proxy timeout, network blip) killed the entire session permanently.
2. The accept loop checked `ctx.Done()` but not `net.ErrClosed`, so closing the listener internally produced a spurious warning and an infinite loop.
3. The stale accept goroutine from the previous `startMuxPortForwarding` call could grab connections from the new TCP listener and try to `OpenStream` on a closed muxSession.

## Test plan

- [x] All existing unit tests pass (`go test ./... -race`)
- [x] `TestPortForwardingReconnect` acceptance test: starts forwarder with `--enable-reconnect=true`, verifies SSH banner, terminates the SSM session via SDK, waits for port to recover, verifies SSH banner again
- [x] Existing port-forwarding acceptance tests unaffected
- [x] Port-forwarding session exits cleanly when context is cancelled (no spurious warnings)
- [x] Basic (non-mux) port-forwarding path unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)