### PR TITLE
Fix mux port-forwarding WebSocket drop under NLB/VPC-endpoint idle timeout

### DIFF
--- a/ssmclient/port_forwarding.go
+++ b/ssmclient/port_forwarding.go
@@ -117,7 +117,7 @@ func startMuxPortForwardingSession(ctx context.Context, c *datachannel.SsmDataCh
 	current := c
 	reconnectCount := 0
 	for {
-		bridgeErr := startMuxPortForwarding(ctx, current, lsnr, current.AgentVersion())
+		bridgeErr := startMuxPortForwarding(ctx, current, lsnr)
 
 		select {
 		case <-ctx.Done():

--- a/ssmclient/port_mux.go
+++ b/ssmclient/port_mux.go
@@ -15,19 +15,17 @@ import (
 
 // startMuxPortForwarding handles multiplexed port forwarding using the smux library.
 // This allows multiple concurrent TCP connections over a single SSM session.
-// Agent version must be >= 3.0.196.0 for multiplexing support.
-func startMuxPortForwarding(ctx context.Context, c *datachannel.SsmDataChannel, listener net.Listener, agentVersion string) error {
+func startMuxPortForwarding(ctx context.Context, c *datachannel.SsmDataChannel, listener net.Listener) error {
 	// Create a pipe to bridge between the data channel and smux
 	localConn, pipeConn := net.Pipe()
 
-	// Configure smux session
+	// Configure smux session.
+	// Keep smux keepalive enabled regardless of agent version: it sends a small
+	// NOP frame every 10s in both directions, which prevents NLB/VPC-endpoint
+	// idle-timeout from dropping the WebSocket when there is no application data.
+	// Agent-side keepalives (output_stream_data acks) are server-to-client only
+	// and are not sufficient to satisfy bidirectional idle-timeout policies.
 	smuxConfig := smux.DefaultConfig()
-
-	// Disable KeepAlive for agent versions >= 3.1.1511.0
-	// Newer agents handle keepalive at the WebSocket layer
-	if agentVersionGte(agentVersion, "3.1.1511.0") {
-		smuxConfig.KeepAliveDisabled = true
-	}
 
 	// Create smux client session
 	muxSession, err := smux.Client(localConn, smuxConfig)


### PR DESCRIPTION
## Summary

- smux keepalive was unconditionally disabled for agent >= 3.1.1511.0, leaving no client-originated frames flowing through the WebSocket when idle
- NLB/VPC-endpoint idle timeout (~30s minimum on AWS NLBs) then drops the connection, causing an endless reconnect loop
- Agent-side keepalives are server-to-client only and do not satisfy bidirectional idle-timeout policies
- Remove the `KeepAliveDisabled` branch so smux always sends a NOP frame every 10s in both directions — negligible overhead, fixes the drop

## Root cause

`smux.DefaultConfig()` sets `KeepAliveInterval: 10s` / `KeepAliveTimeout: 30s`. The disabled keepalive meant zero bidirectional frames during idle periods, which matched exactly the ~30s drop reported in environments using VPC endpoints (PrivateLink).

## Test plan

- [ ] Existing acceptance tests pass (`TestPortForwardingReconnect`, `TestPortForwardingMultipleConnections`)
- [ ] Manual verification: idle port-forwarding session to RDS via VPC endpoints stays alive beyond 30s

🤖 Generated with [Claude Code](https://claude.com/claude-code)