### PR TITLE
fix(sso): CreateToken polling busy-loops forever on non-pending errors; token error wraps the wrong variable

### DIFF
--- a/session/sso.go
+++ b/session/sso.go
@@ -5,6 +5,7 @@ package session
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -18,6 +19,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials/ssocreds"
 	"github.com/aws/aws-sdk-go-v2/service/sso"
 	"github.com/aws/aws-sdk-go-v2/service/ssooidc"
+	oidctypes "github.com/aws/aws-sdk-go-v2/service/ssooidc/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/pkg/browser"
 	"go.uber.org/zap"
@@ -373,34 +375,23 @@ func ssoLoginFlow(
 		_, _ = fmt.Fprintf(urlWriter, "Open the following URL in your browser: %s\n", authUrl)
 	}
 
-	var createTokenErr error
-	token := new(ssooidc.CreateTokenOutput)
+	// Poll at the interval requested by the authorization server, if it provided one.
 	sleepPerCycle := 2 * time.Second
-	startTime := time.Now()
-	delta := time.Since(startTime)
-
-	for delta < loginTimeout {
-		// Keep trying until the user approves the request in the browser
-		token, createTokenErr = ssoOidcClient.CreateToken(
-			ctx, &ssooidc.CreateTokenInput{
-				ClientId:     registerClient.ClientId,
-				ClientSecret: registerClient.ClientSecret,
-				DeviceCode:   deviceAuth.DeviceCode,
-				GrantType:    aws.String("urn:ietf:params:oauth:grant-type:device_code"),
-			},
-		)
-		if createTokenErr == nil {
-			break
-		}
-		if strings.Contains(createTokenErr.Error(), "AuthorizationPendingException") {
-			time.Sleep(sleepPerCycle)
-			delta = time.Since(startTime)
-			continue
-		}
+	if deviceAuth.Interval > 0 {
+		sleepPerCycle = time.Duration(deviceAuth.Interval) * time.Second
 	}
-	// Checks to see if there is a valid token after the login timeout ends
+
+	token, createTokenErr := pollCreateToken(
+		ctx, ssoOidcClient, &ssooidc.CreateTokenInput{
+			ClientId:     registerClient.ClientId,
+			ClientSecret: registerClient.ClientSecret,
+			DeviceCode:   deviceAuth.DeviceCode,
+			GrantType:    aws.String("urn:ietf:params:oauth:grant-type:device_code"),
+		},
+		loginTimeout, sleepPerCycle,
+	)
 	if createTokenErr != nil || token.AccessToken == nil {
-		return nil, SsoOidcTokenCreationError{err}
+		return nil, SsoOidcTokenCreationError{createTokenErr}
 	}
 	cacheFile := cacheFileData{
 		StartUrl:              profile.ssoStartUrl,
@@ -413,6 +404,54 @@ func ssoLoginFlow(
 	}
 
 	return &cacheFile, nil
+}
+
+// createTokenAPI is the subset of the SSO OIDC client used by pollCreateToken.
+type createTokenAPI interface {
+	CreateToken(ctx context.Context, params *ssooidc.CreateTokenInput, optFns ...func(*ssooidc.Options)) (*ssooidc.CreateTokenOutput, error)
+}
+
+// pollCreateToken polls CreateToken until the user approves the device authorization
+// request, the timeout elapses, or a non-retryable error occurs. While authorization is
+// pending it sleeps for interval between attempts; a SlowDownException lengthens the
+// interval by 5 seconds, per RFC 8628 §3.5. The returned CreateTokenOutput is never nil.
+func pollCreateToken(
+	ctx context.Context,
+	client createTokenAPI,
+	in *ssooidc.CreateTokenInput,
+	timeout time.Duration,
+	interval time.Duration,
+) (*ssooidc.CreateTokenOutput, error) {
+	deadline := time.Now().Add(timeout)
+
+	for {
+		token, err := client.CreateToken(ctx, in)
+		if err == nil {
+			if token == nil {
+				token = new(ssooidc.CreateTokenOutput)
+			}
+			return token, nil
+		}
+
+		var pending *oidctypes.AuthorizationPendingException
+		var slowDown *oidctypes.SlowDownException
+		switch {
+		case errors.As(err, &pending):
+			// keep polling at the current interval
+		case errors.As(err, &slowDown):
+			interval += 5 * time.Second
+		default:
+			// invalid/expired device code, throttling other than slow_down, network
+			// failure, etc. — retrying cannot succeed, and looping without sleeping
+			// would hammer the endpoint
+			return new(ssooidc.CreateTokenOutput), err
+		}
+
+		if time.Now().Add(interval).After(deadline) {
+			return new(ssooidc.CreateTokenOutput), err
+		}
+		time.Sleep(interval)
+	}
 }
 
 func getCallerID(ctx context.Context) (*sts.GetCallerIdentityOutput, error) {

--- a/session/sso_poll_test.go
+++ b/session/sso_poll_test.go
@@ -1,0 +1,139 @@
+package session
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ssooidc"
+	oidctypes "github.com/aws/aws-sdk-go-v2/service/ssooidc/types"
+)
+
+// stubTokenClient returns each queued response in order; the last one repeats.
+type stubTokenClient struct {
+	responses []stubTokenResponse
+	calls     int
+}
+
+type stubTokenResponse struct {
+	token *ssooidc.CreateTokenOutput
+	err   error
+}
+
+func (s *stubTokenClient) CreateToken(
+	_ context.Context, _ *ssooidc.CreateTokenInput, _ ...func(*ssooidc.Options),
+) (*ssooidc.CreateTokenOutput, error) {
+	idx := s.calls
+	if idx >= len(s.responses) {
+		idx = len(s.responses) - 1
+	}
+	s.calls++
+	r := s.responses[idx]
+	return r.token, r.err
+}
+
+func TestPollCreateToken_PendingThenSuccess(t *testing.T) {
+	want := &ssooidc.CreateTokenOutput{AccessToken: aws.String("token-123")}
+	client := &stubTokenClient{responses: []stubTokenResponse{
+		{err: &oidctypes.AuthorizationPendingException{}},
+		{err: &oidctypes.AuthorizationPendingException{}},
+		{token: want},
+	}}
+
+	got, err := pollCreateToken(t.Context(), client, &ssooidc.CreateTokenInput{}, 5*time.Second, time.Millisecond)
+	if err != nil {
+		t.Fatalf("pollCreateToken() error: %v", err)
+	}
+	if got != want {
+		t.Fatalf("pollCreateToken() = %v, want the stubbed token", got)
+	}
+	if client.calls != 3 {
+		t.Errorf("CreateToken called %d times, want 3", client.calls)
+	}
+}
+
+// TestPollCreateToken_NonRetryableErrorStopsPolling guards the busy-loop fix: the old
+// loop neither slept, broke, nor advanced its timeout clock on errors other than
+// AuthorizationPendingException, spinning against the OIDC endpoint forever.
+func TestPollCreateToken_NonRetryableErrorStopsPolling(t *testing.T) {
+	fatal := &oidctypes.ExpiredTokenException{}
+	client := &stubTokenClient{responses: []stubTokenResponse{{err: fatal}}}
+
+	start := time.Now()
+	_, err := pollCreateToken(t.Context(), client, &ssooidc.CreateTokenInput{}, 5*time.Second, time.Millisecond)
+	if !errors.Is(err, fatal) {
+		t.Fatalf("pollCreateToken() error = %v, want the fatal CreateToken error", err)
+	}
+	if client.calls != 1 {
+		t.Errorf("CreateToken called %d times, want 1 (no retry on non-retryable error)", client.calls)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("pollCreateToken() took %v, should return immediately", elapsed)
+	}
+}
+
+func TestPollCreateToken_TimeoutWhilePending(t *testing.T) {
+	client := &stubTokenClient{responses: []stubTokenResponse{
+		{err: &oidctypes.AuthorizationPendingException{}},
+	}}
+
+	start := time.Now()
+	_, err := pollCreateToken(t.Context(), client, &ssooidc.CreateTokenInput{}, 100*time.Millisecond, 20*time.Millisecond)
+	if err == nil {
+		t.Fatal("pollCreateToken() error = nil, want the pending error at timeout")
+	}
+	var pending *oidctypes.AuthorizationPendingException
+	if !errors.As(err, &pending) {
+		t.Fatalf("pollCreateToken() error = %v, want AuthorizationPendingException", err)
+	}
+	elapsed := time.Since(start)
+	if elapsed > 2*time.Second {
+		t.Fatalf("pollCreateToken() took %v, want ~the 100ms timeout", elapsed)
+	}
+	// with a 20ms interval and 100ms budget the loop makes a bounded number of
+	// attempts — a busy loop would make thousands
+	if client.calls > 10 {
+		t.Errorf("CreateToken called %d times in 100ms, polling is not sleeping", client.calls)
+	}
+}
+
+// TestPollCreateToken_SlowDownLengthensInterval verifies RFC 8628 §3.5 handling: a
+// slow_down error must both keep polling and increase the wait, so the +5s bump pushes
+// the next attempt past this test's short deadline — exactly 2 calls, no tight retries.
+func TestPollCreateToken_SlowDownLengthensInterval(t *testing.T) {
+	client := &stubTokenClient{responses: []stubTokenResponse{
+		{err: &oidctypes.SlowDownException{}},
+	}}
+
+	start := time.Now()
+	_, err := pollCreateToken(t.Context(), client, &ssooidc.CreateTokenInput{}, 300*time.Millisecond, time.Millisecond)
+	if err == nil {
+		t.Fatal("pollCreateToken() error = nil, want slow_down error at timeout")
+	}
+	var slowDown *oidctypes.SlowDownException
+	if !errors.As(err, &slowDown) {
+		t.Fatalf("pollCreateToken() error = %v, want SlowDownException", err)
+	}
+	if client.calls != 1 {
+		t.Errorf("CreateToken called %d times, want 1 (interval+5s exceeds the deadline)", client.calls)
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Errorf("pollCreateToken() took %v, must not sleep past the deadline", elapsed)
+	}
+}
+
+func TestPollCreateToken_NeverReturnsNilToken(t *testing.T) {
+	client := &stubTokenClient{responses: []stubTokenResponse{
+		{err: &oidctypes.ExpiredTokenException{}},
+	}}
+
+	token, err := pollCreateToken(t.Context(), client, &ssooidc.CreateTokenInput{}, time.Second, time.Millisecond)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if token == nil {
+		t.Fatal("pollCreateToken() returned a nil token; callers dereference token.AccessToken")
+	}
+}


### PR DESCRIPTION
## Bug 1 — unbounded busy-loop against the SSO OIDC endpoint

In `ssoLoginFlow`, the device-authorization polling loop only slept and re-measured `delta` inside the `AuthorizationPendingException` branch:

```go
for delta < loginTimeout {
    token, createTokenErr = ssoOidcClient.CreateToken(ctx, ...)
    if createTokenErr == nil { break }
    if strings.Contains(createTokenErr.Error(), "AuthorizationPendingException") {
        time.Sleep(sleepPerCycle)
        delta = time.Since(startTime)
        continue
    }
    // any other error: no break, no sleep, no delta update
}
```

Any other error — expired device code, `SlowDownException`, transient network failure — fell through without breaking, sleeping, or advancing `delta`, so `delta < loginTimeout` stayed true forever and the loop hammered the OIDC endpoint at full speed until the process was killed.

## Bug 2 — the reported error is not the real one

The failure path wrapped the stale `err` from earlier in the function (typically `nil` on the headless path) instead of `createTokenErr`:

```go
if createTokenErr != nil || token.AccessToken == nil {
    return nil, SsoOidcTokenCreationError{err}   // err, not createTokenErr
}
```

so users got a token-creation error that unwrapped to nothing, hiding the actual cause.

## Fix

The loop is extracted into `pollCreateToken`, which:

- matches retryable errors by SDK type (`errors.As` on `ssooidc/types`) instead of substring search on the error string;
- returns immediately on non-retryable errors;
- keeps polling on `AuthorizationPendingException`, honouring the polling interval returned by `StartDeviceAuthorization` when the server provides one (falling back to the previous 2s);
- lengthens the interval by 5 seconds on `SlowDownException`, per RFC 8628 §3.5;
- stops at the deadline and returns the last error so the caller can wrap it.

The call site now wraps `createTokenErr`.

## Verification

- `go test ./... -race` passes.
- New `session/sso_poll_test.go` drives `pollCreateToken` with a stubbed client: pending→success, non-retryable stop (asserts exactly one call and immediate return — the busy-loop regression guard), timeout-while-pending with a bounded attempt count, slow_down interval growth, and the never-nil-token contract.
- Mutation-checked: treating non-retryable errors as pending, or dropping the slow_down interval bump, each makes its guarding test fail.

Related: #95 (same audit; independent change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)