### PR TITLE
fix(config): CLI flags lose to config file/env for two flags; swallowed command errors; SDK log formatting

### DIFF
--- a/cmd/ec2instance_connect.go
+++ b/cmd/ec2instance_connect.go
@@ -4,6 +4,7 @@ import (
 	"github.com/alexbacchin/ssm-session-client/config"
 	"github.com/alexbacchin/ssm-session-client/session"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var ec2InstanceConnectCmd = &cobra.Command{
@@ -16,12 +17,14 @@ var ec2InstanceConnectCmd = &cobra.Command{
 			return cmd.Help()
 		}
 		session.InitializeClient()
-		session.StartEC2InstanceConnect(args[0])
-		return nil
+		return session.StartEC2InstanceConnect(args[0])
 	},
 }
 
 func init() {
 	ec2InstanceConnectCmd.Flags().StringVar(&config.Flags().SSHPublicKeyFile, "ssh-public-key-file", "", "SSH public key that will be send via EC2 Instance Connect")
+	// Without this binding, preRun's viper.Unmarshal would overwrite an explicit
+	// CLI flag with a config-file or SSC_ env value.
+	viper.BindPFlag("ssh-public-key-file", ec2InstanceConnectCmd.Flags().Lookup("ssh-public-key-file"))
 	rootCmd.AddCommand(ec2InstanceConnectCmd)
 }

--- a/cmd/flag_precedence_test.go
+++ b/cmd/flag_precedence_test.go
@@ -1,0 +1,81 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/alexbacchin/ssm-session-client/config"
+	"github.com/spf13/viper"
+)
+
+// loadTestConfig points viper at a temp config file and restores an empty config layer
+// (and the affected Config fields) when the test finishes.
+func loadTestConfig(t *testing.T, yaml string) {
+	t.Helper()
+	// preRun calls config.SetLogLevel, which needs the logger's atomic level built
+	if _, err := config.CreateLogger(); err != nil {
+		t.Fatalf("init logger: %v", err)
+	}
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte(yaml), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	viper.SetConfigFile(cfgPath)
+	if err := viper.ReadInConfig(); err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+
+	kbps := config.Flags().PortForwardKbps
+	keyFile := config.Flags().SSHPublicKeyFile
+	t.Cleanup(func() {
+		viper.SetConfigType("yaml")
+		if err := viper.ReadConfig(strings.NewReader("")); err != nil {
+			t.Errorf("reset viper config layer: %v", err)
+		}
+		config.Flags().PortForwardKbps = kbps
+		config.Flags().SSHPublicKeyFile = keyFile
+	})
+}
+
+// TestPortForwardKbps_Precedence guards the missing viper.BindPFlag: without it,
+// preRun's viper.Unmarshal overwrote an explicit --port-forward-kbps with the
+// config-file value.
+func TestPortForwardKbps_Precedence(t *testing.T) {
+	loadTestConfig(t, "port-forward-kbps: 250\n")
+
+	// flag not set on the command line: the config file value applies
+	preRun(portForwardingCmd, nil)
+	if got := config.Flags().PortForwardKbps; got != 250 {
+		t.Fatalf("config-file value: PortForwardKbps = %d, want 250", got)
+	}
+
+	// explicit CLI flag: must beat the config file
+	if err := portForwardingCmd.Flags().Set("port-forward-kbps", "750"); err != nil {
+		t.Fatalf("set flag: %v", err)
+	}
+	preRun(portForwardingCmd, nil)
+	if got := config.Flags().PortForwardKbps; got != 750 {
+		t.Fatalf("explicit flag: PortForwardKbps = %d, want 750 (config file must not override a set flag)", got)
+	}
+}
+
+// TestSSHPublicKeyFile_Precedence is the same guard for instance-connect's
+// --ssh-public-key-file.
+func TestSSHPublicKeyFile_Precedence(t *testing.T) {
+	loadTestConfig(t, "ssh-public-key-file: /from/config.pub\n")
+
+	preRun(ec2InstanceConnectCmd, nil)
+	if got := config.Flags().SSHPublicKeyFile; got != "/from/config.pub" {
+		t.Fatalf("config-file value: SSHPublicKeyFile = %q, want /from/config.pub", got)
+	}
+
+	if err := ec2InstanceConnectCmd.Flags().Set("ssh-public-key-file", "/from/flag.pub"); err != nil {
+		t.Fatalf("set flag: %v", err)
+	}
+	preRun(ec2InstanceConnectCmd, nil)
+	if got := config.Flags().SSHPublicKeyFile; got != "/from/flag.pub" {
+		t.Fatalf("explicit flag: SSHPublicKeyFile = %q, want /from/flag.pub (config file must not override a set flag)", got)
+	}
+}

--- a/cmd/ssm_port_forwarding.go
+++ b/cmd/ssm_port_forwarding.go
@@ -6,6 +6,7 @@ import (
 	"github.com/alexbacchin/ssm-session-client/config"
 	"github.com/alexbacchin/ssm-session-client/session"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var (
@@ -42,5 +43,8 @@ func init() {
 	portForwardingCmd.Flags().IntVar(&portForwardingLocalPort, "local-port", 0, "Local port to listen on (default: random)")
 	portForwardingCmd.Flags().StringVar(&portForwardingHost, "host", "", "Remote host reachable from the instance to forward to")
 	portForwardingCmd.Flags().IntVar(&config.Flags().PortForwardKbps, "port-forward-kbps", 1000, "Outbound rate limit in kbps (0 = no limit)")
+	// Without this binding, preRun's viper.Unmarshal would overwrite an explicit
+	// CLI flag with a config-file or SSC_ env value.
+	viper.BindPFlag("port-forward-kbps", portForwardingCmd.Flags().Lookup("port-forward-kbps"))
 	rootCmd.AddCommand(portForwardingCmd)
 }

--- a/cmd/ssm_shell.go
+++ b/cmd/ssm_shell.go
@@ -10,9 +10,9 @@ var ssmShellCmd = &cobra.Command{
 	Short: "Start a SSM Shell Session",
 	Long:  `Start a SSM SesShellsion via AWS SSM Session Manager`,
 	Args:  cobra.MatchAll(cobra.MinimumNArgs(1), cobra.OnlyValidArgs),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		session.InitializeClient()
-		session.StartSSMShell(args[0])
+		return session.StartSSMShell(args[0])
 	},
 }
 

--- a/session/client.go
+++ b/session/client.go
@@ -29,17 +29,7 @@ func ProxyHttpClient() *awshttp.BuildableClient {
 	return client
 }
 func InitializeClient() {
-	if profile, ok := os.LookupEnv("AWS_PROFILE"); ok {
-		config.Flags().AWSProfile = profile
-	}
-
-	if region, ok := os.LookupEnv("AWS_DEFAULT_REGION"); ok {
-		config.Flags().AWSRegion = region
-	}
-
-	if region, ok := os.LookupEnv("AWS_REGION"); ok {
-		config.Flags().AWSRegion = region
-	}
+	applyAWSEnvFallbacks()
 	if config.Flags().AWSRegion == "" {
 		zap.S().Fatal("AWS Region is not set")
 		return
@@ -91,18 +81,43 @@ func InitializeClient() {
 	}
 }
 
+// applyAWSEnvFallbacks fills profile/region from the AWS-native environment variables
+// only when nothing set them yet (CLI flag, SSC_ env var, or config file). An explicit
+// --aws-profile/--aws-region must not be overridden by ambient environment.
+// AWS_REGION takes priority over the legacy AWS_DEFAULT_REGION, matching the SDK.
+func applyAWSEnvFallbacks() {
+	if config.Flags().AWSProfile == "" {
+		if profile, ok := os.LookupEnv("AWS_PROFILE"); ok {
+			config.Flags().AWSProfile = profile
+		}
+	}
+
+	if config.Flags().AWSRegion == "" {
+		if region, ok := os.LookupEnv("AWS_REGION"); ok {
+			config.Flags().AWSRegion = region
+		} else if region, ok := os.LookupEnv("AWS_DEFAULT_REGION"); ok {
+			config.Flags().AWSRegion = region
+		}
+	}
+}
+
+// sdkLogger routes AWS SDK log output through the zap logger.
+func sdkLogger() logging.Logger {
+	return logging.LoggerFunc(func(classification logging.Classification, format string, v ...interface{}) {
+		if classification == logging.Warn {
+			zap.S().Warnf(format, v...)
+		} else {
+			zap.S().Debugf(format, v...)
+		}
+	})
+}
+
 func BuildAWSConfig(ctx context.Context, service string) (aws.Config, error) {
 
 	var cfg aws.Config
 	var err error
 
-	logger := logging.LoggerFunc(func(classification logging.Classification, format string, v ...interface{}) {
-		if classification == logging.Warn {
-			zap.S().Warnf(format, v)
-		} else {
-			zap.S().Debugf(format, v)
-		}
-	})
+	logger := sdkLogger()
 
 	if config.Flags().AWSProfile != "" {
 		cfg, err = awsconfig.LoadDefaultConfig(ctx,

--- a/session/client_env_test.go
+++ b/session/client_env_test.go
@@ -1,0 +1,99 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/alexbacchin/ssm-session-client/config"
+	"github.com/aws/smithy-go/logging"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func saveFlags(t *testing.T) {
+	t.Helper()
+	profile, region := config.Flags().AWSProfile, config.Flags().AWSRegion
+	t.Cleanup(func() {
+		config.Flags().AWSProfile = profile
+		config.Flags().AWSRegion = region
+	})
+}
+
+// TestApplyAWSEnvFallbacks_ExplicitValuesWin guards the precedence fix: an explicit
+// --aws-profile/--aws-region (or config value) must not be overwritten by ambient
+// AWS_* environment variables.
+func TestApplyAWSEnvFallbacks_ExplicitValuesWin(t *testing.T) {
+	saveFlags(t)
+	t.Setenv("AWS_PROFILE", "env-profile")
+	t.Setenv("AWS_REGION", "us-east-1")
+	t.Setenv("AWS_DEFAULT_REGION", "eu-west-1")
+	config.Flags().AWSProfile = "flag-profile"
+	config.Flags().AWSRegion = "us-west-2"
+
+	applyAWSEnvFallbacks()
+
+	if got := config.Flags().AWSProfile; got != "flag-profile" {
+		t.Errorf("AWSProfile = %q, want the explicit %q (env must not override)", got, "flag-profile")
+	}
+	if got := config.Flags().AWSRegion; got != "us-west-2" {
+		t.Errorf("AWSRegion = %q, want the explicit %q (env must not override)", got, "us-west-2")
+	}
+}
+
+func TestApplyAWSEnvFallbacks_EnvFillsUnset(t *testing.T) {
+	saveFlags(t)
+	t.Setenv("AWS_PROFILE", "env-profile")
+	t.Setenv("AWS_REGION", "us-east-1")
+	t.Setenv("AWS_DEFAULT_REGION", "eu-west-1")
+	config.Flags().AWSProfile = ""
+	config.Flags().AWSRegion = ""
+
+	applyAWSEnvFallbacks()
+
+	if got := config.Flags().AWSProfile; got != "env-profile" {
+		t.Errorf("AWSProfile = %q, want %q from AWS_PROFILE", got, "env-profile")
+	}
+	if got := config.Flags().AWSRegion; got != "us-east-1" {
+		t.Errorf("AWSRegion = %q, want %q (AWS_REGION beats AWS_DEFAULT_REGION)", got, "us-east-1")
+	}
+}
+
+func TestApplyAWSEnvFallbacks_DefaultRegionFallback(t *testing.T) {
+	saveFlags(t)
+	t.Setenv("AWS_DEFAULT_REGION", "eu-west-1")
+	config.Flags().AWSRegion = ""
+
+	applyAWSEnvFallbacks()
+
+	if got := config.Flags().AWSRegion; got != "eu-west-1" {
+		t.Errorf("AWSRegion = %q, want %q from AWS_DEFAULT_REGION", got, "eu-west-1")
+	}
+}
+
+// TestSdkLogger_FormatsVariadicArgs guards the v... fix: passing the slice instead of
+// expanding it rendered SDK log lines as "[...]" with %!s(MISSING) placeholders.
+func TestSdkLogger_FormatsVariadicArgs(t *testing.T) {
+	core, logs := observer.New(zapcore.DebugLevel)
+	restore := zap.ReplaceGlobals(zap.New(core))
+	defer restore()
+
+	sdkLogger().Logf(logging.Warn, "retrying %s request after %s", "GET", "1s")
+	sdkLogger().Logf(logging.Debug, "request %s took %s", "PUT", "2s")
+
+	entries := logs.All()
+	if len(entries) != 2 {
+		t.Fatalf("got %d log entries, want 2", len(entries))
+	}
+	if entries[0].Message != "retrying GET request after 1s" {
+		t.Errorf("warn message = %q, want %q", entries[0].Message, "retrying GET request after 1s")
+	}
+	if entries[0].Level != zapcore.WarnLevel {
+		t.Errorf("first entry level = %v, want warn", entries[0].Level)
+	}
+	if entries[1].Message != "request PUT took 2s" {
+		t.Errorf("debug message = %q, want %q", entries[1].Message, "request PUT took 2s")
+	}
+	if entries[1].Level != zapcore.DebugLevel {
+		t.Errorf("second entry level = %v, want debug", entries[1].Level)
+	}
+}


### PR DESCRIPTION
## Fixes

**1. `--port-forward-kbps` and `--ssh-public-key-file` are overridden by the config file / `SSC_` env vars.**
These are the only two flags registered without a `viper.BindPFlag` call, so `preRun`'s `viper.Unmarshal(config.Flags())` overwrites the explicitly-passed CLI value whenever the same key exists in `.ssm-session-client.yaml` or as an `SSC_` env var — inverting the documented precedence (CLI flags highest). Both are now bound, like every other flag in `root.go`.

**2. `AWS_PROFILE`/`AWS_REGION`/`AWS_DEFAULT_REGION` override explicit `--aws-profile`/`--aws-region`.**
`InitializeClient` unconditionally copied these env vars over the resolved flags, so `AWS_REGION=us-east-1 ssm-session-client shell ... --aws-region us-west-2` used us-east-1. They are now fallbacks applied only when nothing else set a value (with `AWS_REGION` beating the legacy `AWS_DEFAULT_REGION`, matching the SDK's own precedence). Verified end to end against the built binary: the debug log now shows the SDK dispatching to us-west-2 in the scenario above.

**3. `shell` and `instance-connect` exit 0 on failure.**
`shell` used `Run` (not `RunE`) and `instance-connect` ignored `StartEC2InstanceConnect`'s return value, so session failures were invisible to scripts. Both now propagate the error like the sibling commands (`ssh`, `ssh-direct`, `port-forwarding`).

**4. AWS SDK log lines render as `%!s(MISSING)` garbage.**
The SDK `LoggerFunc` passed the variadic slice `v` instead of `v...` to `zap.S().Warnf`/`Debugf`.

## Verification

- `go test ./... -race` passes; each fix has a new test (flag-vs-config-file precedence driven through `preRun`, env-fallback matrix with `t.Setenv`, zap-observer assertion on the formatted SDK log line), and each test was **mutation-checked**: reverting the fix it guards makes it fail while the rest of the suite passes.

## Notes for the maintainer (not changed here — judgment calls)

- `--port-forward-kbps` defaults to 1000 (= 125,000 B/s), which is ~2× the 500 kbps SSM agent cap referenced by `ssmclient/throttle.go`'s own comment (the pre-rename default `port-forward-bps=56000` sat just under it). Worth reconciling the default or the comment.
- `session/sso.go` debug-logs `params`/`loginOutput` structs that embed `*aws.Credentials`; at `--log-level debug` these go to the on-disk `app.log`. Consider redacting.
- `CLAUDE.md` references a `pkg/` directory and `.github/workflows/pages.yml`, neither of which exists (logic lives in `session/`/`ssmclient/`; the docs workflows are `deploy-docs*.yml`).
- The `zap.S().Fatal(...)` calls inside `error`-returning functions across `session/` bypass deferred cleanup and make the returned errors mostly dead; converting them to returned errors would be a larger, mechanical follow-up if you're open to it.

Related: #95, #96 (same audit; independent changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)