### PR TITLE
fix(test): verify tag/alias resolution with a real connection

### DIFF
--- a/test/acceptance/port_forwarding_acceptance_test.go
+++ b/test/acceptance/port_forwarding_acceptance_test.go
@@ -276,15 +276,26 @@ func TestPortForwardingToRDPPort(t *testing.T) {
 // entire subprocess if the handshake hangs or the process exits prematurely.
 func startPortForwarder(t *testing.T, i InfraOutputs, localPort, remotePort int, extraArgs ...string) {
 	t.Helper()
+	startPortForwarderToTarget(t, i, i.InstanceID, nil, localPort, remotePort, extraArgs...)
+}
+
+// startPortForwarderToTarget is like startPortForwarder but resolves an arbitrary target
+// string (e.g. a tag "Key:Value" or an alias name) instead of always using the instance
+// ID, and allows extra global flags (e.g. --alias) to be inserted before the subcommand.
+func startPortForwarderToTarget(t *testing.T, i InfraOutputs, target string, globalArgs []string, localPort, remotePort int, extraArgs ...string) {
+	t.Helper()
 	args := []string{
 		"--config", "/dev/null",
 		"--log-level", "debug",
 		"--aws-region", i.AWSRegion,
 		"--enable-reconnect=false",
-		"port-forwarding", i.InstanceID,
+	}
+	args = append(args, globalArgs...)
+	args = append(args,
+		"port-forwarding", target,
 		"--remote-port", strconv.Itoa(remotePort),
 		"--local-port", strconv.Itoa(localPort),
-	}
+	)
 	args = append(args, extraArgs...)
 	// Note: --config and --log-level are also added by runCmd, but startPortForwarder
 	// uses exec.CommandContext directly, so these are needed here.

--- a/test/acceptance/resolver_acceptance_test.go
+++ b/test/acceptance/resolver_acceptance_test.go
@@ -3,6 +3,8 @@
 package acceptance
 
 import (
+	"fmt"
+	"net"
 	"strings"
 	"testing"
 	"time"
@@ -11,30 +13,32 @@ import (
 const resolverTimeout = 90 * time.Second
 
 // TestResolveByTag verifies the tag-resolver strategy against the real EC2 API.
-// Uses the shell command because ssh-direct's user@host[:port] target format
-// conflicts with the tag Key:Value format. The shell command passes the raw
-// target to ResolveTarget which handles tags correctly.
-// We verify that the process does NOT fail with a resolution error.
+// Uses port-forwarding (rather than shell) because ssh-direct's user@host[:port]
+// target format conflicts with the tag Key:Value format, while port-forwarding
+// takes the raw target and passes it straight to ResolveTarget, and — unlike
+// shell — doesn't need a TTY to fully establish a session. A real TCP connection
+// through the tunnel proves resolution actually located the right instance,
+// rather than just checking stderr for the absence of failure strings.
 func TestResolveByTag(t *testing.T) {
 	i := infra(t)
 	waitForSSMReady(t, i.InstanceID)
-	// The shell command in non-TTY mode doesn't cleanly terminate SSM sessions,
-	// so we skip the leak checker and clean up sessions after the test instead.
-	t.Cleanup(func() { terminateAllSessions(t, i.InstanceID) })
+	terminateAllSessions(t, i.InstanceID)
+	registerSessionLeakCheck(t, i.InstanceID)
 
 	target := i.AliasTagKey + ":" + i.AliasTagValue
-	_, stderr, code := runCmd(t, resolverTimeout, "shell", target)
-	// The shell command will likely fail because stdin is not a TTY, but that's OK.
-	// We only care that target resolution succeeded (no resolution error in stderr).
-	if code != 0 {
-		lower := strings.ToLower(stderr)
-		if strings.Contains(lower, "no instances") || strings.Contains(lower, "could not resolve") ||
-			strings.Contains(lower, "not found") {
-			t.Fatalf("tag resolver failed: %s", stderr)
-		}
-		// Non-zero exit from TTY/session issue is acceptable — resolution worked.
-		t.Logf("shell exited %d (expected for non-TTY stdin); stderr: %s", code, stderr)
+	localPort := freePort(t)
+	startPortForwarderToTarget(t, i, target, nil, localPort, 22)
+
+	conn, err := net.DialTimeout("tcp", fmt.Sprintf("localhost:%d", localPort), 5*time.Second)
+	if err != nil {
+		t.Fatalf("tag resolver: connect to forwarded port %d: %v", localPort, err)
 	}
+	buf := make([]byte, 256)
+	_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	if n, _ := conn.Read(buf); n > 0 {
+		t.Logf("SSH banner: %s", strings.TrimSpace(string(buf[:n])))
+	}
+	conn.Close()
 }
 
 // TestResolveByIP verifies the IP-resolver strategy against the real EC2 API.

--- a/test/acceptance/shell_acceptance_test.go
+++ b/test/acceptance/shell_acceptance_test.go
@@ -3,6 +3,8 @@
 package acceptance
 
 import (
+	"fmt"
+	"net"
 	"strings"
 	"testing"
 	"time"
@@ -35,48 +37,57 @@ func TestShellByInstanceID(t *testing.T) {
 }
 
 // TestShellByTag verifies target resolution via tag (Name:<value>).
-// Uses the shell command because ssh-direct's user@host[:port] format
-// conflicts with the tag Key:Value format. The shell command passes the
-// raw target to ResolveTarget which handles tags correctly.
+// Uses port-forwarding (rather than shell) because ssh-direct's user@host[:port]
+// format conflicts with the tag Key:Value format, while port-forwarding takes
+// the raw target and passes it straight to ResolveTarget, and doesn't need a
+// TTY to fully establish a session. A real TCP connection through the tunnel
+// proves resolution actually located the right instance.
 func TestShellByTag(t *testing.T) {
 	i := infra(t)
 	waitForSSMReady(t, i.InstanceID)
-	// The shell command in non-TTY mode doesn't cleanly terminate SSM sessions,
-	// so we skip the leak checker and clean up sessions after the test instead.
-	t.Cleanup(func() { terminateAllSessions(t, i.InstanceID) })
+	terminateAllSessions(t, i.InstanceID)
+	registerSessionLeakCheck(t, i.InstanceID)
 
 	target := i.AliasTagKey + ":" + i.AliasTagValue
-	_, stderr, code := runCmd(t, shellTimeout, "shell", target)
-	// The shell command may fail due to non-TTY stdin, but target resolution should succeed.
-	if code != 0 {
-		lower := strings.ToLower(stderr)
-		if strings.Contains(lower, "no instances") || strings.Contains(lower, "could not resolve") ||
-			strings.Contains(lower, "not found") || strings.Contains(lower, "invalid") {
-			t.Fatalf("tag resolution failed: %s", stderr)
-		}
-		t.Logf("shell exited %d (expected for non-TTY stdin); tag resolution succeeded", code)
+	localPort := freePort(t)
+	startPortForwarderToTarget(t, i, target, nil, localPort, 22)
+
+	conn, err := net.DialTimeout("tcp", fmt.Sprintf("localhost:%d", localPort), 5*time.Second)
+	if err != nil {
+		t.Fatalf("tag resolution: connect to forwarded port %d: %v", localPort, err)
 	}
+	buf := make([]byte, 256)
+	_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	if n, _ := conn.Read(buf); n > 0 {
+		t.Logf("SSH banner: %s", strings.TrimSpace(string(buf[:n])))
+	}
+	conn.Close()
 }
 
 // TestShellByAlias verifies target resolution via a named alias (--alias flag).
+// Uses port-forwarding for the same reasons as TestShellByTag; an alias name
+// has no ":" so it would also work with ssh-direct, but port-forwarding is used
+// for consistency and to avoid the TTY dependency.
 func TestShellByAlias(t *testing.T) {
 	i := infra(t)
 	waitForSSMReady(t, i.InstanceID)
-	// The shell command in non-TTY mode doesn't cleanly terminate SSM sessions.
-	t.Cleanup(func() { terminateAllSessions(t, i.InstanceID) })
+	terminateAllSessions(t, i.InstanceID)
+	registerSessionLeakCheck(t, i.InstanceID)
 
 	aliasFlag := "test-alias=" + i.AliasTagKey + ":" + i.AliasTagValue
-	_, stderr, code := runCmd(t, shellTimeout, "--alias", aliasFlag, "shell", "test-alias")
-	// Same as TestShellByTag: shell may fail on TTY but alias resolution should work.
-	if code != 0 {
-		lower := strings.ToLower(stderr)
-		if strings.Contains(lower, "no instances") || strings.Contains(lower, "could not resolve") ||
-			strings.Contains(lower, "not found") || strings.Contains(lower, "invalid") ||
-			strings.Contains(lower, "alias") {
-			t.Fatalf("alias resolution failed: %s", stderr)
-		}
-		t.Logf("shell exited %d (expected for non-TTY stdin); alias resolution succeeded", code)
+	localPort := freePort(t)
+	startPortForwarderToTarget(t, i, "test-alias", []string{"--alias", aliasFlag}, localPort, 22)
+
+	conn, err := net.DialTimeout("tcp", fmt.Sprintf("localhost:%d", localPort), 5*time.Second)
+	if err != nil {
+		t.Fatalf("alias resolution: connect to forwarded port %d: %v", localPort, err)
 	}
+	buf := make([]byte, 256)
+	_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	if n, _ := conn.Read(buf); n > 0 {
+		t.Logf("SSH banner: %s", strings.TrimSpace(string(buf[:n])))
+	}
+	conn.Close()
 }
 
 // TestShellByPrivateIP verifies target resolution via the instance's private IP.


### PR DESCRIPTION
## Summary
- `TestResolveByTag`, `TestShellByTag`, and `TestShellByAlias` used the `shell` command, which needs a TTY that the test harness can't provide, so they inferred resolution success from the *absence* of certain failure substrings in stderr instead of asserting anything concrete.
- That approach caused a false failure in `TestShellByAlias`: its check for the substring `"alias"` matched cobra's own `--alias` flag description in the printed usage/help text, not an actual resolution error.
- All three tests now use `port-forwarding` instead — it accepts the raw target (sidestepping `ssh-direct`'s `user@host:port` conflict with tag `Key:Value` syntax) and doesn't need a TTY — then verify resolution by making a real TCP connection through the tunnel and reading the SSH banner, the same pattern already used by `TestPortForwardingToSSHPort`.
- Added `startPortForwarderToTarget` (generalizing `startPortForwarder`) to allow an arbitrary target string and extra global flags (e.g. `--alias`); existing call sites are unchanged.

## Test plan
- [x] `go build -tags acceptance ./...`
- [x] `go vet -tags acceptance ./test/acceptance/...`
- [x] `gofmt -l` on changed files (clean)
- [ ] `AWS_PROFILE=sandbox AWS_REGION=ap-southeast-2 go test ./test/acceptance/... -tags acceptance -v -timeout 20m -count=1 -race -run 'TestResolveByTag|TestShellByTag|TestShellByAlias'` against real AWS infra

🤖 Generated with [Claude Code](https://claude.com/claude-code)