### PR TITLE
fix(test): isolate AWS_REGION from ambient env in DefaultRegionFallback test

### DIFF
--- a/session/client_env_test.go
+++ b/session/client_env_test.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"os"
 	"testing"
 
 	"github.com/alexbacchin/ssm-session-client/config"
@@ -60,6 +61,10 @@ func TestApplyAWSEnvFallbacks_EnvFillsUnset(t *testing.T) {
 
 func TestApplyAWSEnvFallbacks_DefaultRegionFallback(t *testing.T) {
 	saveFlags(t)
+	if orig, ok := os.LookupEnv("AWS_REGION"); ok {
+		os.Unsetenv("AWS_REGION")
+		t.Cleanup(func() { os.Setenv("AWS_REGION", orig) })
+	}
 	t.Setenv("AWS_DEFAULT_REGION", "eu-west-1")
 	config.Flags().AWSRegion = ""
 


### PR DESCRIPTION
## Summary
- `TestApplyAWSEnvFallbacks_DefaultRegionFallback` (added in #97) only set `AWS_DEFAULT_REGION`, but `applyAWSEnvFallbacks` prefers `AWS_REGION` over `AWS_DEFAULT_REGION` by design.
- Any developer shell with `AWS_REGION` already exported leaks into the test, shadowing the intended fallback value and failing the assertion — not a bug in `applyAWSEnvFallbacks` itself, just a non-hermetic test.
- Fix: unset `AWS_REGION` for the duration of the test (restoring via `t.Cleanup`) so the assertion is isolated from ambient shell state.

## Test plan
- [x] `go test ./session/... -run TestApplyAWSEnvFallbacks -v` passes
- [x] `go test ./... -race` passes across all packages