### PR TITLE
fix(release): pin release_tag for go-release-action uploads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,12 +169,17 @@ jobs:
           if [ -z "$PREV_TAG" ]; then
             echo "body=Initial release" >> "$GITHUB_OUTPUT"
           else
-            LOG=$(git log --pretty=format:"- %s (%h)" "${PREV_TAG}..HEAD" -- . ':!test/')
+            LOG=$(git log --no-merges --pretty=format:"- %s (%h)" "${PREV_TAG}..HEAD" -- . ':!test/')
+            CONTRIBUTORS=$(git log --no-merges --pretty=format:"%an" "${PREV_TAG}..HEAD" -- . ':!test/' | sort -u | sed 's/^/- /')
             {
               echo "body<<CHANGELOG_EOF"
               echo "## Changes since ${PREV_TAG}"
               echo ""
               echo "$LOG"
+              echo ""
+              echo "## Contributors"
+              echo ""
+              echo "$CONTRIBUTORS"
               echo "CHANGELOG_EOF"
             } >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,6 +243,7 @@ jobs:
       - uses: wangyoucao577/go-release-action@v1.53
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          release_tag: ${{ github.event.inputs.version }}
           goos: ${{ matrix.goos }}
           goarch: ${{ matrix.goarch }}
           goversion: ${{ steps.go-version.outputs.version }}
@@ -269,6 +270,7 @@ jobs:
       - uses: wangyoucao577/go-release-action@v1.53
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          release_tag: ${{ github.event.inputs.version }}
           goos: linux
           goarch: arm
           goarm: ${{ matrix.goarm }}


### PR DESCRIPTION
## Summary
- Stage 5 (`release-binaries` / `release-binaries-arm`) was failing with a 404 against `releases/tags/main` when uploading binaries.
- `wangyoucao577/go-release-action` uploads to a release determined by its `release_tag` input, which defaults to empty and falls back to `GITHUB_REF` (the triggering branch, `main`) rather than the release version — checking out `ref: ${{ github.event.inputs.version }}` doesn't affect this.
- Fix: explicitly pass `release_tag: ${{ github.event.inputs.version }}` to both `go-release-action` steps so uploads target the correct release created in Stage 4.

## Test plan
- [ ] Run the Release workflow via `workflow_dispatch` and confirm Stage 5 uploads succeed against the correct release tag instead of `main`.