### PR TITLE
fix(release): stop skip-acceptance from skipping the entire release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,6 +229,7 @@ jobs:
     name: Build ${{ matrix.goos }}/${{ matrix.goarch }}
     needs: create-release
     runs-on: ubuntu-latest
+    if: always() && needs.create-release.result == 'success'
     strategy:
       matrix:
         goos: [linux, darwin]
@@ -260,6 +261,7 @@ jobs:
     name: Build linux/arm${{ matrix.goarm }}
     needs: create-release
     runs-on: ubuntu-latest
+    if: always() && needs.create-release.result == 'success'
     strategy:
       matrix:
         goarm: ["6", "7"]
@@ -288,6 +290,7 @@ jobs:
     name: Build windows/${{ matrix.goarch }} (signed)
     needs: create-release
     runs-on: ubuntu-latest
+    if: always() && needs.create-release.result == 'success'
     strategy:
       matrix:
         goarch: [amd64, arm64]
@@ -370,6 +373,11 @@ jobs:
     name: Trigger documentation deployment
     needs: [release-binaries, release-binaries-arm, release-windows-signed]
     runs-on: ubuntu-latest
+    if: >-
+      always() &&
+      needs.release-binaries.result == 'success' &&
+      needs.release-binaries-arm.result == 'success' &&
+      needs.release-windows-signed.result == 'success'
     permissions:
       actions: write
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,6 +146,7 @@ jobs:
     name: Create GitHub release
     needs: create-tag
     runs-on: ubuntu-latest
+    if: always() && needs.create-tag.result == 'success'
     steps:
       - uses: actions/checkout@v7
         with:


### PR DESCRIPTION
## Summary
- Setting `skip-acceptance: true` was skipping not just `acceptance-tests`, but every job after it (`create-release`, all binary builds, docs deploy) — only the git tag got created.
- Root cause: jobs with no explicit `if:` default to `success()`, which walks the *entire* upstream DAG (not just direct `needs`). Once `acceptance-tests` reports `skipped`, that implicit check evaluates false for every downstream job, cascading the skip all the way through.
- `create-tag` already worked around this with an explicit `always() && (... == 'success' || ... == 'skipped')` condition — it was the only stage protected.

## Fix
Add explicit `always()`-guarded conditions to every remaining stage (`create-release`, `release-binaries`, `release-binaries-arm`, `release-windows-signed`, `trigger-deploy-docs`) so each one only requires its **direct** dependency to have succeeded, rather than relying on the DAG-wide implicit `success()`. `acceptance-tests` remains the only job that's allowed to be skipped.

## Test plan
- [ ] Run the Release workflow via `workflow_dispatch` with `skip-acceptance: true` and confirm all stages run through to docs deployment.
- [ ] Run the Release workflow with `skip-acceptance: false` and confirm behavior is unchanged when acceptance tests pass.