### PR TITLE
fix(release): attribute changelog entries and contributors to GitHub usernames

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,6 +154,8 @@ jobs:
 
       - name: Generate changelog
         id: changelog
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION="${{ github.event.inputs.version }}"
           IS_PRERELEASE=false
@@ -171,7 +173,14 @@ jobs:
             echo "body=Initial release" >> "$GITHUB_OUTPUT"
           else
             LOG=$(git log --no-merges --pretty=format:"- %s (%h)" "${PREV_TAG}..HEAD" -- . ':!test/')
-            CONTRIBUTORS=$(git log --no-merges --pretty=format:"%an" "${PREV_TAG}..HEAD" -- . ':!test/' | sort -u | sed 's/^/- /')
+
+            CONTRIBUTORS=$(
+              git log --no-merges --pretty=format:"%H" "${PREV_TAG}..HEAD" -- . ':!test/' | \
+              while read -r sha; do
+                gh api "repos/${{ github.repository }}/commits/${sha}" --jq '.author.login // empty'
+              done | grep -v '^$' | sort -u | sed 's/^/- @/'
+            )
+
             {
               echo "body<<CHANGELOG_EOF"
               echo "## Changes since ${PREV_TAG}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,14 +172,19 @@ jobs:
           if [ -z "$PREV_TAG" ]; then
             echo "body=Initial release" >> "$GITHUB_OUTPUT"
           else
-            LOG=$(git log --no-merges --pretty=format:"- %s (%h)" "${PREV_TAG}..HEAD" -- . ':!test/')
+            LOG=""
+            LOGINS=""
+            while IFS=$'\t' read -r sha subject; do
+              login=$(gh api "repos/${{ github.repository }}/commits/${sha}" --jq '.author.login // empty')
+              if [ -n "$login" ]; then
+                LOG="${LOG}- ${subject} (${sha:0:7}, @${login})"$'\n'
+                LOGINS="${LOGINS}${login}"$'\n'
+              else
+                LOG="${LOG}- ${subject} (${sha:0:7})"$'\n'
+              fi
+            done < <(git log --no-merges --pretty=format:"%H%x09%s" "${PREV_TAG}..HEAD" -- . ':!test/')
 
-            CONTRIBUTORS=$(
-              git log --no-merges --pretty=format:"%H" "${PREV_TAG}..HEAD" -- . ':!test/' | \
-              while read -r sha; do
-                gh api "repos/${{ github.repository }}/commits/${sha}" --jq '.author.login // empty'
-              done | grep -v '^$' | sort -u | sed 's/^/- @/'
-            )
+            CONTRIBUTORS=$(printf '%s' "$LOGINS" | grep -v '^$' | sort -u | sed 's/^/- @/')
 
             {
               echo "body<<CHANGELOG_EOF"

--- a/docs/index.html
+++ b/docs/index.html
@@ -1325,6 +1325,38 @@ scp -P 2222 file.tar.gz ec2-user@localhost:/tmp/</code></pre>
         </li>
       </ul>
 
+      <h3 id="port-forward-kbps">Why <code>--port-forward-kbps</code> exists</h3>
+      <p>
+        Multiplexed port forwarding uses <a href="https://github.com/xtaci/smux" target="_blank" rel="noopener">smux</a>
+        to run multiple TCP connections over one SSM session. The smux protocol has two
+        wire versions: v1, with no flow control, and v2, which adds per-stream flow control
+        via acknowledgement frames. <code>ssm-session-client</code> and the AWS-managed
+        <code>session-manager-plugin</code>/SSM Agent must agree on the protocol version, and
+        as of this writing the AWS side only negotiates smux v1 — it constructs its session
+        with the library's unmodified default config, which is v1. This isn't tied to a
+        specific SSM Agent version; every current agent speaks v1 only, so
+        <code>ssm-session-client</code> cannot unilaterally switch to v2.
+      </p>
+      <p>
+        Without v2's flow control, an unthrottled multiplexed stream can write data faster
+        than the SSM Agent's session-wide cap (roughly 500 kbps) can drain it. When that
+        happens the smux receive buffer fills, backpressure stalls the WebSocket reader, the
+        agent stops receiving acknowledgements, and it eventually terminates the session
+        mid-transfer. <code>--port-forward-kbps</code> (default 1000, <code>0</code> disables
+        it) paces outbound writes on each forwarded stream to stay under that cap and avoid
+        the stall.
+      </p>
+      <p>
+        AWS's own <code>session-manager-plugin</code> works around the same v1 limitation
+        internally: its client&rarr;agent bridge loop sleeps for 1 ms after every read/send
+        cycle, capping aggregate throughput to a fixed, hardcoded rate. It isn't user
+        configurable and doesn't provide per-stream fairness — it just keeps the shared pipe
+        under the agent's cap. <code>--port-forward-kbps</code> is the same category of
+        workaround, made tunable instead of fixed. The only real fix would be smux v2
+        support landing in AWS's <code>session-manager-plugin</code>/Agent; until then, this
+        flag isn't removable.
+      </p>
+
     </section>
 
     <!-- ============================================================


### PR DESCRIPTION
## Summary
- The contributors section added in #104 used `git log --pretty=format:"%an"` (the local git author name), which can be inconsistent across machines/configs and isn't a real GitHub identity — no `@mention`, no link to a profile.
- Switched to resolving each commit's SHA via `gh api repos/:owner/:repo/commits/:sha` and reading `.author.login`, which GitHub derives from the commit's associated account. Falls back to omitting the commit from the contributors list (rather than a blank entry) when no GitHub account is linked.
- Each changelog line now also appends the resolved username, e.g. `- <subject> (<sha>, @<username>)`, reusing the same commit lookups so there's no extra API cost. Falls back to just `(<sha>)` when unresolved.
- Also includes an unrelated docs addition: a new section in `docs/index.html` explaining why `--port-forward-kbps` exists (the smux v1/v2 protocol mismatch with AWS's `session-manager-plugin`/SSM Agent, and how the flag compares to `session-manager-plugin`'s own hardcoded throttling workaround).

## Test plan
- [ ] Run the Release workflow via `workflow_dispatch` and confirm each changelog entry and the "Contributors" section show `@username` correctly, with no blank/malformed entries.
- [ ] Preview `docs/index.html` locally and confirm the new `--port-forward-kbps` section renders correctly.